### PR TITLE
Make the script run on a mac

### DIFF
--- a/scripts/configure-karydia-webhook
+++ b/scripts/configure-karydia-webhook
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-ca_bundle="$(kubectl get configmap -n kube-system extension-apiserver-authentication -o=jsonpath='{.data.client-ca-file}' | base64 | tr -d '\n')"
+ca_bundle="$(kubectl get configmap -n kube-system extension-apiserver-authentication -o=jsonpath='{.data.client-ca-file}' | base64 | tr -d '\r\n')"
 if [[ -z "${ca_bundle}" ]]; then
   echo "ERROR: extension-apiserver-authentication config map with CA bundle not found - aborting" >&2
   exit 1

--- a/scripts/create-karydia-certificate
+++ b/scripts/create-karydia-certificate
@@ -63,7 +63,7 @@ metadata:
 spec:
   groups:
   - system:authenticated
-  request: '$(base64 "${tmp_dir}/karydia.csr" | tr -d '\n')'
+  request: '$(base64 "${tmp_dir}/karydia.csr" | tr -d '\r\n')'
   usages:
   - digital signature
   - key encipherment


### PR DESCRIPTION
It appears that cr's or cr nl's are introduced into the certificate files. This works now on the mac.