### PR TITLE
Make karydia webhook both mutating and validating

### DIFF
--- a/pkg/admission/interface.go
+++ b/pkg/admission/interface.go
@@ -5,5 +5,7 @@ import (
 )
 
 type AdmissionPlugin interface {
-	Admit(v1beta1.AdmissionReview) *v1beta1.AdmissionResponse
+	// Admit takes an admission review and a boolean flag if the
+	// mutation of specs (i.e. patching) is allowed.
+	Admit(v1beta1.AdmissionReview, bool) *v1beta1.AdmissionResponse
 }

--- a/pkg/admission/karydiasecuritypolicy/pod.go
+++ b/pkg/admission/karydiasecuritypolicy/pod.go
@@ -13,7 +13,7 @@ import (
 	"github.com/kinvolk/karydia/pkg/k8sutil/scheme"
 )
 
-func (k *KarydiaSecurityPolicyAdmission) computeSecurityContextPod(ar v1beta1.AdmissionReview, specMutationAllowed bool, policies []*v1alpha1.KarydiaSecurityPolicy) *v1beta1.AdmissionResponse {
+func (k *KarydiaSecurityPolicyAdmission) computeSecurityContextPod(ar v1beta1.AdmissionReview, mutationAllowed bool, policies []*v1alpha1.KarydiaSecurityPolicy) *v1beta1.AdmissionResponse {
 	if ar.Request.Operation != v1beta1.Create {
 		return &v1beta1.AdmissionResponse{
 			Allowed: true,
@@ -43,7 +43,7 @@ func (k *KarydiaSecurityPolicyAdmission) computeSecurityContextPod(ar v1beta1.Ad
 			continue
 		}
 
-		if len(patches) > 0 && !specMutationAllowed {
+		if len(patches) > 0 && !mutationAllowed {
 			continue
 		}
 
@@ -54,7 +54,7 @@ func (k *KarydiaSecurityPolicyAdmission) computeSecurityContextPod(ar v1beta1.Ad
 			}
 		}
 
-		if specMutationAllowed && acceptedWithPatches == nil {
+		if mutationAllowed && acceptedWithPatches == nil {
 			patchesStr := strings.Join(patches, ",")
 			patchType := v1beta1.PatchTypeJSONPatch
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -43,7 +43,12 @@ func New(config *Config, webhook *webhook.Webhook) (*Server, error) {
 
 	mux.HandleFunc("/healthz", server.handlerHealthz)
 	if webhook != nil {
-		mux.HandleFunc("/webhook", webhook.Serve)
+		mux.HandleFunc("/webhook/validating", func(w http.ResponseWriter, r *http.Request) {
+			webhook.Serve(w, r, false)
+		})
+		mux.HandleFunc("/webhook/mutating", func(w http.ResponseWriter, r *http.Request) {
+			webhook.Serve(w, r, true)
+		})
 	}
 
 	httpServer := &http.Server{

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -44,10 +44,10 @@ func (wh *Webhook) RegisterAdmissionPlugin(p admission.AdmissionPlugin) {
 	wh.admissionPlugins = append(wh.admissionPlugins, p)
 }
 
-func (wh *Webhook) admit(ar v1beta1.AdmissionReview) *v1beta1.AdmissionResponse {
+func (wh *Webhook) admit(ar v1beta1.AdmissionReview, mutationAllowed bool) *v1beta1.AdmissionResponse {
 	var responseWithPatches *v1beta1.AdmissionResponse
 	for _, ap := range wh.admissionPlugins {
-		response := ap.Admit(ar)
+		response := ap.Admit(ar, mutationAllowed)
 		if !response.Allowed {
 			return response
 		}
@@ -65,7 +65,7 @@ func (wh *Webhook) admit(ar v1beta1.AdmissionReview) *v1beta1.AdmissionResponse 
 	return &v1beta1.AdmissionResponse{Allowed: true}
 }
 
-func (wh *Webhook) Serve(w http.ResponseWriter, r *http.Request) {
+func (wh *Webhook) Serve(w http.ResponseWriter, r *http.Request, mutationAllowed bool) {
 	if r.Method != "POST" {
 		wh.logger.Errorf("received unexpected %s request, expecting POST", r.Method)
 		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
@@ -107,7 +107,7 @@ func (wh *Webhook) Serve(w http.ResponseWriter, r *http.Request) {
 		responseAdmissionReview.Response = k8sutil.ErrToAdmissionResponse(err)
 	} else {
 		wh.logger.Debugf("received admission review request: %+v", requestedAdmissionReview.Request)
-		responseAdmissionReview.Response = wh.admit(requestedAdmissionReview)
+		responseAdmissionReview.Response = wh.admit(requestedAdmissionReview, mutationAllowed)
 	}
 
 	// Make sure to return the request UID

--- a/scripts/configure-karydia-webhook
+++ b/scripts/configure-karydia-webhook
@@ -10,6 +10,40 @@ fi
 
 cat <<EOF | sed -e "s|{{CA_BUNDLE}}|${ca_bundle}|g" | kubectl apply -f -
 apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: karydia-webhook
+  labels:
+    app: karydia
+webhooks:
+  - name: karydia.gardener.cloud
+    failurePolicy: Ignore
+    clientConfig:
+      service:
+        name: karydia
+        namespace: kube-system
+        path: "/webhook/validating"
+      caBundle: {{CA_BUNDLE}}
+    rules:
+      # https://github.com/kubernetes/kubernetes/blob/v1.12.1/staging/src/k8s.io/api/admissionregistration/v1beta1/types.go
+      - operations:
+        - CREATE
+        - UPDATE
+        apiGroups: ["*"]
+        apiVersions: ["*"]
+        resources:
+        - nodes
+        - namespaces
+        - pods
+        - pods/status
+        - endpoints
+        - persistentvolumes
+        - validatingwebhookconfigurations
+        - mutatingwebhookconfigurations
+EOF
+
+cat <<EOF | sed -e "s|{{CA_BUNDLE}}|${ca_bundle}|g" | kubectl apply -f -
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
   name: karydia-webhook
@@ -22,7 +56,7 @@ webhooks:
       service:
         name: karydia
         namespace: kube-system
-        path: "/webhook"
+        path: "/webhook/mutating"
       caBundle: {{CA_BUNDLE}}
     rules:
       # https://github.com/kubernetes/kubernetes/blob/v1.12.1/staging/src/k8s.io/api/admissionregistration/v1beta1/types.go


### PR DESCRIPTION
By default through `scripts/configure-karydia-webhook` we configure
both, but users are free to chose depending on their use case and
requirements.

Resolves #13