### PR TITLE
pkg/admission/karydia: read namespace from admission request

### DIFF
--- a/pkg/admission/karydia/karydia.go
+++ b/pkg/admission/karydia/karydia.go
@@ -79,11 +79,11 @@ func (k *KarydiaAdmission) AdmitPod(ar v1beta1.AdmissionReview, mutationAllowed 
 		return k8sutil.ErrToAdmissionResponse(fmt.Errorf("failed to decode object: %v", err))
 	}
 
-	namespacePod := pod.ObjectMeta.Namespace
-	if namespacePod == "" {
-		namespacePod = "default"
+	namespaceRequest := ar.Request.Namespace
+	if namespaceRequest == "" {
+		return k8sutil.ErrToAdmissionResponse(fmt.Errorf("received request with empty namespace"))
 	}
-	namespace, err := k.kubeClientset.CoreV1().Namespaces().Get(namespacePod, metav1.GetOptions{})
+	namespace, err := k.kubeClientset.CoreV1().Namespaces().Get(namespaceRequest, metav1.GetOptions{})
 	if err != nil {
 		return k8sutil.ErrToAdmissionResponse(fmt.Errorf("failed to determine pod's namespace: %v", err))
 	}


### PR DESCRIPTION
For an incoming admission request, we need to know the target namespace
in order to read per-namespace configuration and handle the request
accordingly. Since the namespace of the target object isn't always
populated from the beginning, read the namespace from the admission
request instead.

Note that there can be admission requests where namespace is not set,
it's an optional field. In the case of pod admission, we probably can
expect it though and error out if not set.