### PR TITLE
rbac: correctly deploy karydia in the control plane

### DIFF
--- a/contrib/gardener/manifests/rbac-cp.yml
+++ b/contrib/gardener/manifests/rbac-cp.yml
@@ -1,0 +1,128 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: karydia-view-ksp
+rules:
+- apiGroups: ["karydia.gardener.cloud"]
+  resources: ["karydiasecuritypolicies"]
+  verbs: ["get", "watch", "list"]
+
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: karydia-networkpolicies
+rules:
+- apiGroups: ["networking.k8s.io"]
+  resources: ["networkpolicies"]
+  verbs: ["get", "watch", "list", "create", "patch", "update"]
+
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: karydia-view
+subjects:
+- kind: User
+  name: system:karydia
+  apiGroup: rbac.authorization.k8s.io
+- kind: User
+  name: system:kubemgmt
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: view
+  apiGroup: rbac.authorization.k8s.io
+
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: karydia-networkpolicies
+subjects:
+- kind: User
+  name: system:karydia
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: karydia-networkpolicies
+  apiGroup: rbac.authorization.k8s.io
+
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: karydia-view-ksp
+subjects:
+- kind: User
+  name: system:karydia
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: karydia-view-ksp
+  apiGroup: rbac.authorization.k8s.io
+
+---
+
+# Define role for OPA/kube-mgmt to update configmaps with policy status.
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: opa
+  name: configmap-modifier
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["update", "patch"]
+
+---
+
+# Grant OPA/kube-mgmt role defined above.
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: opa
+  name: opa-configmap-modifier
+subjects:
+- kind: User
+  name: system:kubemgmt
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: configmap-modifier
+  apiGroup: rbac.authorization.k8s.io
+
+---
+
+# Define role for OPA/kube-mgmt to cache the resources
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kubemgmt-cacher
+rules:
+- apiGroups: [""]
+  resources: ["nodes", "namespaces", "persistentvolumes", "pods", "endpoints"]
+  verbs: ["get", "watch", "list"]
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources: ["validatingwebhookconfigurations", "mutatingwebhookconfigurations"]
+  verbs: ["get", "watch", "list"]
+
+---
+
+# Grant OPA/kube-mgmt role defined above.
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kubemgmt-cacher
+subjects:
+- kind: User
+  name: system:kubemgmt
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: kubemgmt-cacher
+  apiGroup: rbac.authorization.k8s.io

--- a/contrib/gardener/scripts/create-karydia-kubeconfig-cp
+++ b/contrib/gardener/scripts/create-karydia-kubeconfig-cp
@@ -1,0 +1,113 @@
+#!/bin/bash
+
+set -euo pipefail
+
+for req in kubectl openssl; do
+  if ! command -v "${req}" &>/dev/null; then
+    echo "'${req}' required but not found" >&2
+    exit 1
+  fi
+done
+
+
+readonly subject_name="${SUBJECT_NAME:-karydia}"
+readonly namespace="${NAMESPACE:-shoot--foo--bar}"
+readonly cafile="${CA:-ca.pem}"
+readonly cert_path="${CERT_PATH:-${subject_name}-cp.pem}"
+readonly key_path="${KEY_PATH:-${subject_name}-cp-key.pem}"
+readonly kubeconfig_out="${KUBECONFIG_OUT:-${subject_name}-cp.kubeconfig}"
+
+readonly csr_name="${subject_name}.${namespace}"
+
+if [[ -e "${cert_path}" ]] || [[ -e "${key_path}" ]]; then
+  echo "ERROR: found existing '${cert_path}' or '${key_path} - aborting" >&2
+  exit 1
+fi
+
+readonly tmp_dir="$(mktemp -d /tmp/karydia-csr-XXXX)"
+
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+cat <<EOF >"${tmp_dir}/csr.conf"
+[req]
+req_extensions = v3_req
+distinguished_name = req_distinguished_name
+[req_distinguished_name]
+[ v3_req ]
+basicConstraints = CA:FALSE
+keyUsage = digitalSignature, keyEncipherment
+extendedKeyUsage = clientAuth
+subjectAltName = @alt_names
+[alt_names]
+DNS.1 = karydia
+DNS.2 = karydia.${namespace}
+DNS.3 = karydia.${namespace}.svc
+DNS.4 = 127.0.0.1
+DNS.5 = localhost
+EOF
+
+openssl genrsa -out "${key_path}" 2048
+openssl req -new \
+  -key "${key_path}" \
+  -subj "/CN=system:${subject_name}" \
+  -config "${tmp_dir}/csr.conf" \
+  -out "${tmp_dir}/${subject_name}.csr"
+
+# Clean-up any previously created CSR for our service
+kubectl delete csr "${csr_name}" &>/dev/null || true
+
+cat <<EOF | kubectl create -f -
+apiVersion: certificates.k8s.io/v1beta1
+kind: CertificateSigningRequest
+metadata:
+  name: ${csr_name}
+spec:
+  groups:
+  - system:authenticated
+  request: '$(base64 "${tmp_dir}/${subject_name}.csr" | tr -d '\r\n')'
+  usages:
+  - digital signature
+  - key encipherment
+  - client auth
+EOF
+
+echo "Waiting for CSR '${csr_name}' to be created ..."
+until kubectl get csr "${csr_name}" &>/dev/null; do sleep 1; done
+
+# Approve the CSR
+kubectl certificate approve "${csr_name}"
+
+# Verify certificate has been signed
+for _ in {1..10}; do
+  cert="$(kubectl get csr "${csr_name}" -o jsonpath='{.status.certificate}')"
+  if [[ -n "${cert}" ]]; then
+    break
+  fi
+  sleep 1
+done
+if [[ -z "${cert}" ]]; then
+  echo "ERROR: after approving CSR '${csr_name}', the signed certificate did not appear on the resource - aborting" >&2
+  exit 1
+fi
+
+echo "${cert}" | openssl base64 -d -A -out "${cert_path}"
+
+kubectl config set-cluster ${namespace} \
+  --certificate-authority=${cafile} \
+  --embed-certs=true \
+  --server=https://kube-apiserver \
+  --kubeconfig=${kubeconfig_out}
+
+kubectl config set-credentials system:${subject_name} \
+  --client-certificate=${cert_path} \
+  --client-key=${key_path} \
+  --embed-certs=true \
+  --kubeconfig=${kubeconfig_out}
+
+kubectl config set-context default \
+  --cluster=${namespace} \
+  --user=system:${subject_name} \
+  --kubeconfig=${kubeconfig_out}
+
+kubectl config use-context default \
+  --kubeconfig=${kubeconfig_out}

--- a/contrib/gardener/scripts/deploy-karydia-cp
+++ b/contrib/gardener/scripts/deploy-karydia-cp
@@ -38,37 +38,38 @@ if [[ -z "${restrictedendpointcidr}" ]]; then
   exit 1
 fi
 
+kubemgmt_kubeconfig_bundle="$(cat kubemgmt-cp.kubeconfig | base64 | tr -d '\r\n')"
+if [[ -z "${kubemgmt_kubeconfig_bundle}" ]]; then
+  echo "ERROR: kube-mgmt kubeconfig not found - aborting" >&2
+  exit 1
+fi
+
+karydia_kubeconfig_bundle="$(cat karydia-cp.kubeconfig | base64 | tr -d '\r\n')"
+if [[ -z "${karydia_kubeconfig_bundle}" ]]; then
+  echo "ERROR: karydia kubeconfig not found - aborting" >&2
+  exit 1
+fi
+
 cmd=apply
 if [[ "$@" == "delete" ]]; then
   cmd=delete
 fi
 
-cat <<EOF | sed -e "s|{{NAMESPACE}}|${namespace}|g" -e "s|{{CLUSTERNAME}}|${clustername}|g" -e "s|{{PODCIDR}}|${podcidr}|g" -e "s|{{NODECIDR}}|${nodecidr}|g" -e "s|{{RESTRICTEDENDPOINTCIDR}}|${restrictedendpointcidr}|g" | kubectl ${cmd} -n ${namespace} -f -
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: karydia
-  namespace: {{NAMESPACE}}
-
----
-
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: karydia
-  namespace: {{NAMESPACE}}
-subjects:
-- kind: ServiceAccount
-  namespace: {{NAMESPACE}}
-  name: karydia
-roleRef:
-  kind: ClusterRole
-  name: cluster-admin
-  apiGroup: rbac.authorization.k8s.io
-
----
+sed \
+	-e "s|{{KUBEMGMT_KUBECONFIG_BUNDLE}}|${kubemgmt_kubeconfig_bundle}|g" \
+	-e "s|{{KARYDIA_KUBECONFIG_BUNDLE}}|${karydia_kubeconfig_bundle}|g" \
+	-e "s|{{NAMESPACE}}|${namespace}|g" \
+	-e "s|{{CLUSTERNAME}}|${clustername}|g" \
+	-e "s|{{PODCIDR}}|${podcidr}|g" \
+	-e "s|{{NODECIDR}}|${nodecidr}|g" \
+	-e "s|{{RESTRICTEDENDPOINTCIDR}}|${restrictedendpointcidr}|g" \
+	<<EOF | kubectl ${cmd} -n ${namespace} -f -
 
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: opa-policies
+  namespace: {{NAMESPACE}}
 data:
   parameters.rego: |
     package parameters
@@ -165,10 +166,28 @@ data:
         requestedName := matched_object.metadata.name
         startswith(matched_object.metadata.name, namePrefix)
     }
-kind: ConfigMap
+
+---
+
+apiVersion: v1
+kind: Secret
 metadata:
-  name: opa-policies
+  name: kube-mgmt-kubeconfig
   namespace: {{NAMESPACE}}
+type: Opaque
+data:
+  kubeconfig: {{KUBEMGMT_KUBECONFIG_BUNDLE}}
+
+---
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: karydia-kubeconfig
+  namespace: {{NAMESPACE}}
+type: Opaque
+data:
+  kubeconfig: {{KARYDIA_KUBECONFIG_BUNDLE}}
 
 ---
 
@@ -186,7 +205,8 @@ spec:
       labels:
         app: karydia
     spec:
-      serviceAccount: karydia
+      serviceAccount: default
+      automountServiceAccountToken: false
       containers:
       - name: karydia
         image: karydia/karydia:0.1.0
@@ -194,6 +214,8 @@ spec:
         command:
           - karydia
           - runserver
+          - --kubeconfig
+          - /etc/karydia/kubeconfig/kubeconfig
           - --tls-cert
           - /etc/karydia/tls/cert.pem
           - --tls-key
@@ -202,6 +224,8 @@ spec:
         volumeMounts:
           - name: karydia-tls
             mountPath: /etc/karydia/tls
+          - name: karydia-kubeconfig
+            mountPath: /etc/karydia/kubeconfig
         livenessProbe:
           httpGet:
             path: /healthz
@@ -236,7 +260,17 @@ spec:
         image: openpolicyagent/kube-mgmt:0.7
         imagePullPolicy: Always
         args:
-          - "--replicate-cluster=v1/pods"
+          - "--kubeconfig=/var/lib/kube-mgmt/kubeconfig"
+          - "--replicate-cluster=v1/nodes"
+          - "--replicate-cluster=v1/namespaces"
+          - "--replicate-cluster=admissionregistration.k8s.io/v1beta1/validatingwebhookconfigurations"
+          - "--replicate-cluster=admissionregistration.k8s.io/v1beta1/mutatingwebhookconfigurations"
+          - "--replicate=v1/persistentvolumes"
+          - "--replicate=v1/pods"
+          - "--replicate=v1/endpoints"
+        volumeMounts:
+        - mountPath: /var/lib/kube-mgmt
+          name: kube-mgmt-kubeconfig
       volumes:
         - name: karydia-tls
           secret:
@@ -244,6 +278,14 @@ spec:
         - name: opa-policies
           configMap:
             name: opa-policies
+        - name: kube-mgmt-kubeconfig
+          secret:
+            defaultMode: 420
+            secretName: kube-mgmt-kubeconfig
+        - name: karydia-kubeconfig
+          secret:
+            defaultMode: 420
+            secretName: karydia-kubeconfig
 
 ---
 


### PR DESCRIPTION
This fixes the scripts and the documentation to install karydia in the
Gardener control plane.
- use RBAC instead of giving admin privileges
  - the rbac config is different than the main one because the {,Cluster}RoleBindings apply to different subjects
- this use a different script to install in the control plane because:
  - we need to use a kubeconfig rather than a ServiceAccount, since it runs in a different Kubernetes cluster
  - we apply a different karydia configuration

This follows similar work in #36
Fixes https://github.com/kinvolk/karydia/issues/38
