### PR TITLE
Enable hotswap of Karydia binary in running cluster for development

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,9 @@
 .ci/
+bin/
 contrib/
 docs/
 logo/
 manifests-dev/
 manifests/
-scripts/
 
 karydia*.pem

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -12,14 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# build
 FROM golang:1.12.0 as build-stage
 RUN mkdir -p /go/src/github.com/karydia/karydia/
 WORKDIR /go/src/github.com/karydia/karydia/
 COPY ./ ./
 RUN make
 
-FROM k8s.gcr.io/debian-base-amd64:0.4.0
+# dev-image (only for development)
+FROM k8s.gcr.io/alpine-with-bash:1.0 as dev-image
+RUN apk update && apk add inotify-tools
+COPY --from=build-stage /go/src/github.com/karydia/karydia/bin/karydia /usr/local/bin/karydia
+COPY ./scripts/hotswap-dev /usr/local/bin/hotswap-dev
+
+# prod-image (production usage)
+FROM k8s.gcr.io/debian-base-amd64:0.4.0 as prod-image
 COPY --from=build-stage /go/src/github.com/karydia/karydia/bin/karydia /usr/local/bin/karydia
 USER 65534:65534
-CMD ["karydia"]
 

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@
 
 IMAGE_REPO=karydia
 IMAGE_NAME=karydia
+DEV_POSTFIX=-dev
 
 KUBERNETES_SERVER ?= ""
 KUBECONFIG_PATH ?= "$(HOME)/.kube/config"
@@ -32,6 +33,14 @@ build:
 .PHONY: container
 container:
 	docker build -t $(IMAGE_REPO)/$(IMAGE_NAME) .
+
+.PHONY: container-dev
+container-dev:
+	docker build -f Dockerfile.dev --target dev-image -t $(IMAGE_REPO)/$(IMAGE_NAME)$(DEV_POSTFIX) .
+
+.PHONY: deploy-dev
+deploy-dev:
+	kubectl cp bin/karydia kube-system/$(shell kubectl get pods -n=kube-system --selector=app=karydia --output=jsonpath='{.items[0].metadata.name}'):/usr/local/bin/karydia$(DEV_POSTFIX)
 
 .PHONY: codegen
 codegen:

--- a/docs/devel/hotswap.md
+++ b/docs/devel/hotswap.md
@@ -1,0 +1,36 @@
+# karydia development with hotswap in running container
+
+## Why
+
+During development it is easier and faster just to build the go binary locally
+and manually test it directly in a already running Kubernetes karydia
+(development) deployment in the cloud rather than building and pushing a new
+Docker image and deploy it to Kubernetes as well.
+
+## Prerequisite
+Make sure your kubectl cli talks to your desired Kubernetes cluster
+
+## Getting started
+
+Follow the steps of [installing karydia](../install.md)
+
+Build the dev karydia container:
+```
+make container-dev
+```
+and push it to your private / enterprise docker registry.
+Adjust `manifests-dev/deployment-dev.yml` to your docker registry image.
+
+Switch from karydia prod to dev Kubernetes deployment:
+```
+kubectl delete -f manifests/deployment.yml
+kubectl apply -f manifests-dev/deployment-dev.yml
+```
+
+Develop a new feature
+
+Build karydia and copy this new karydia go binary directly into the running cloud dev container:
+```
+make build deploy-dev
+```
+

--- a/manifests-dev/deployment-dev.yml
+++ b/manifests-dev/deployment-dev.yml
@@ -1,0 +1,65 @@
+# Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: karydia
+  labels:
+    app: karydia
+  namespace: kube-system
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: karydia
+    spec:
+      serviceAccount: karydia
+      containers:
+      - name: karydia
+        image: karydia/karydia-dev
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+        - name: karydia-tls
+          mountPath: /etc/karydia/tls
+        ports:
+        - containerPort: 33333
+        command:
+        - hotswap-dev
+        - /usr/local/bin/karydia
+        - runserver
+        - --tls-cert
+        - /etc/karydia/tls/cert.pem
+        - --tls-key
+        - /etc/karydia/tls/key.pem
+        - --enable-default-network-policy
+        - --enable-karydia-admission
+        - --enable-opa-admission
+      - name: opa
+        image: openpolicyagent/opa:0.10.2
+        imagePullPolicy: IfNotPresent
+        args:
+        - run
+        - --server
+        - --addr=http://127.0.0.1:8181
+      - name: kube-mgmt
+        image: openpolicyagent/kube-mgmt:0.7
+        imagePullPolicy: Always
+        args:
+        - --replicate-cluster=v1/pods
+      volumes:
+      - name: karydia-tls
+        secret:
+          secretName: karydia-tls

--- a/scripts/generate-deployment-dev
+++ b/scripts/generate-deployment-dev
@@ -1,0 +1,91 @@
+#!/bin/bash
+# Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script is only for development. It generates the dev deployment yaml with a dev container from the prod deployment yaml.
+# This dev deployment yaml replaces the default deployment yaml and thus should  ease and speed up (local) development.
+########################################################### ATTENTION ############################################################
+# Due to different behaviors of 'yq (https://github.com/mikefarah/yq)' per operating system type (e.g. 'darwin', 'linux') this   #
+# script is currently restricted to 'darwin'. [yq version: 2.2.1, go version: 1.12, 2019/03/15]                                  #
+########################################################### ATTENTION ############################################################
+
+set -e
+
+# Setup
+PROD_IMAGE="$1"	# e.g. 'karydia/karydia'
+DEV_IMAGE="$2"	# e.g. 'karydia/karydia-dev'
+PROD_YAML='manifests/deployment.yml'
+DEV_YAML='manifests-dev/deployment-dev.yml'
+DEV_CMD_FIRST='hotswap-dev'
+DEV_CMD_BIN_LOCATION='/usr/local/bin/'
+CMD_MAIN_BIN='karydia'
+ERR_MSG_PREFIX='ERROR'
+
+
+# Check
+
+## prod image and dev image need to be passed
+[ -z "$PROD_IMAGE" ] || [ -z "$DEV_IMAGE" ] && \
+  echo "$ERR_MSG_PREFIX Usage: $0 PROD_DOCKER_IMAGE DEV_DOCKER_IMAGE" >&2 && \
+  exit 1
+
+## operating system must match
+[[ "$OSTYPE" != 'darwin'* ]] && \
+  echo "$ERR_MSG_PREFIX OS type not supported (only 'darwin')" >&2 && \
+  exit 1
+
+## yq must be available
+! type 'yq' &> /dev/null && \
+  echo "$ERR_MSG_PREFIX command not found: yq (https://github.com/mikefarah/yq)" >&2 && \
+  exit 1
+
+
+# Generate
+
+## copy prod deployment yaml
+cp -f "$PROD_YAML" "$DEV_YAML"
+
+## loop through containers specified at deployment yaml
+for ((i=0;;i++))
+do
+
+  ## get container image or break loop if no image found
+  image=$(yq r "$DEV_YAML" "spec.template.spec.containers.$i.image")
+  [ "$image" == 'null' ] && break
+
+  ## change container specification to dev if image equals prod image
+  if [[ "$image" == "$PROD_IMAGE"* ]]
+  then
+    yq w -i "$DEV_YAML" "spec.template.spec.containers.$i.image" -- "$DEV_IMAGE"		# set dev image
+    cmd=$(yq r "$DEV_YAML" "spec.template.spec.containers.$i.command")				# get prod command list
+    size="$(cat <<EOF | wc -l
+$cmd
+EOF)"												# get size of prod command list
+    yq d -i "$DEV_YAML" "spec.template.spec.containers.$i.command"				# delete prod command list
+    yq w -i "$DEV_YAML" "spec.template.spec.containers.$i.command.0" -- "$DEV_CMD_FIRST"	# set first command of dev command list
+    for ((j=0;j<$size;j++))
+    do
+      c="$(cat <<EOF | yq r - $j
+$cmd
+EOF)"												# get each command of prod command list
+      [ "$c" == "$CMD_MAIN_BIN" ] && c="$DEV_CMD_BIN_LOCATION$c"				# if command equals main binary add location
+      yq w -i "$DEV_YAML" "spec.template.spec.containers.$i.command.$((j+1))" -- "$c"		# add command to dev command list
+    done
+    yq d -i "$DEV_YAML" "spec.template.spec.containers.$i.livenessProbe"			# delete liveness probe for dev
+  fi
+done
+
+## success message
+echo "Successfully generated '$DEV_YAML'"
+

--- a/scripts/hotswap-dev
+++ b/scripts/hotswap-dev
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script is only for development. It (hot)swaps the main binary within a running dev container for a new binary.
+# This new binary could be built locally and just copied to the dev container (e.g. with 'kubectl cp'). Afterwards this script kill(s) the running
+# main binary process(es), replaces the main binary with the new one and starts it again.
+
+set -e
+
+# Setup
+MAIN_BIN_PATH="$1"			# e.g. '/usr/local/bin/karydia'
+WATCH_BIN_PATH="$1-dev"			# e.g. '/usr/local/bin/karydia-dev'
+MAIN_BIN=$(basename "$MAIN_BIN_PATH")	# e.g. 'karydia'
+WATCH_BIN=$(basename "$WATCH_BIN_PATH")	# e.g. 'karydia-dev'
+LOG_MAIN="$MAIN_BIN.log"		# e.g. 'karydia.log'
+LOG_SELF=$(basename "$0")'.log'		# e.g. 'hotswap-dev.log'
+LOG_FORMAT='%-23s\t%-4s\t%-6s\t%-11s\t%-18s\t%-8s\n'
+MAX_CYCLES=10
+
+
+# Start
+
+## run main binary in separate process with passed parameters (e.g. $2:'runserver', $3:'--tls-cert', ...) if main binary exists otherwise exit
+[ -e "$MAIN_BIN_PATH" ] && (nohup "$MAIN_BIN_PATH" "${@:2}" > "$LOG_MAIN" &) || exit 1
+
+## log activity to STDOUT and file
+touch "$LOG_SELF"
+echo "$MAIN_BIN_PATH ${@:2}" | tee "$LOG_SELF"
+printf "\n$LOG_FORMAT" 'DATE' 'TYPE' 'USER' 'FILE' 'MESSAGE' 'EVENTS' | tee -a "$LOG_SELF"
+
+
+# Watch
+
+## listen on events in directory of watched file (e.g. '/usr/local/bin/')
+inotifywait -q -m -e create,moved_to $(dirname "$WATCH_BIN_PATH") |
+while read -r dir event file
+do
+
+  ## check if triggered event belongs to specific watched file
+  if [ "$file" == "$WATCH_BIN" ]
+  then
+    msg=''; cnt=1
+
+    ## wait till all processes (e.g. 'kubectl cp') freed watched file otherwise exit after some time
+    while [[ "$(lsof | grep $WATCH_BIN_PATH)" != '' ]]; do sleep 1 && ((cnt++)) && ((cnt>$MAX_CYCLES+1)) && exit 1; done
+
+    ## kill / send 'SIGTERM' to processes who are using main binary
+    kill "$(pgrep $MAIN_BIN_PATH)" &> /dev/null || true
+
+    msg+='killed'; cnt=1
+
+    ## wait till all processes ended who used main binary otherwise exit after some time
+    while [[ "$(lsof | grep $MAIN_BIN_PATH)" != '' ]]; do sleep 1 && ((cnt++)) && ((cnt>$MAX_CYCLES+1)) && exit 1; done
+
+    ## set watched file as new main binary
+    mv -f "$WATCH_BIN_PATH" "$MAIN_BIN_PATH"
+
+    ## run main binary in separate process with passed parameters (e.g. $2:'runserver', $3:'--tls-cert', ...) if main binary exists otherwise exit
+    [ -e "$MAIN_BIN_PATH" ] && (nohup "$MAIN_BIN_PATH" "${@:2}" > "$LOG_MAIN" &) || exit 1
+
+    msg+=' & restarted'; cnt=1
+
+    ## log activity to STDOUT and file
+    touch "$LOG_SELF"
+    printf "$LOG_FORMAT" "$(date +'%F %T %Z')" 'INFO' "$(whoami)" "$file" "$msg" "$event" | tee -a "$LOG_SELF"
+
+  fi
+done
+


### PR DESCRIPTION
For development it is now possible to use
- 'make container-dev' which builds an image with more permissions
which can be deployed to a running K8s Karydia cluster through
applying 'manifests-dev/deployment-dev.yml'
- 'make deploy-dev' which copies the local Karydia binary to the
mentioned container where a hotswap kills the running Karydia
process(es) and starts the newly copied Karydia binary again
This should ease and speed up (local) development.
See docs/devel/hotswap.md for usage information