### PR TITLE
[CI] Run build and unit-tests for pull-requests

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -3,6 +3,7 @@ karydia-pipeline:
         build-image-job:
             traits:
                 version: ~
+                pull_request: ~
                 publish:
                     dockerimages:
                         karydia:


### PR DESCRIPTION
Enable the pull_reqeust trait of the concourse pipline
contract to run the default build and test job when a PR
is labeld with reviewed/ok-to-test