### PR TITLE
Mutate service token pod webhook

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -36,13 +36,16 @@ Karydia Admission (`--enable-karydia-admission`) offers features with the goal
 of hardening a cluster setup.
 
 The features currently supported are:
-- prevent service account token automounts
-- enforcing a seccomp policy
+1. Prevent service account token automounts
+    - `forbidden` prevents pods with any service account token to be deployed
+    - `non-default` prevents pods with the default service account token to be deployed
+    - `remove-default` deploys pods, but removes default service account token when `automountServiceAccountToken` is not explicitly set to `true`.
+2. Enforcing a seccomp policy
 
 It is configured with the following namespace annotations:
 
 | Name | Type | Possible values |
 |---|---|---|
-|karydia.gardener.cloud/automountServiceAccountToken|string|"forbidden" or "non-default"|
-|karydia.gardener.cloud/seccompProfile|string|Name of a valid profile, e.g. "runtime/default" or "localhost/my-profile"|
+|karydia.gardener.cloud/automountServiceAccountToken|string|`forbidden` \| `non-default` \| `remove-default`|
+|karydia.gardener.cloud/seccompProfile|string|Name of a valid profile, e.g. `runtime/default` or `localhost/my-profile`|
 

--- a/pkg/admission/karydia/karydia.go
+++ b/pkg/admission/karydia/karydia.go
@@ -108,11 +108,13 @@ func (k *KarydiaAdmission) AdmitPod(ar v1beta1.AdmissionReview, mutationAllowed 
 	if doCheck {
 		if automountServiceAccountToken == "forbidden" {
 			if doesAutomountServiceAccountToken(&pod) {
-				validationErrors = append(validationErrors, "automount of service account not allowed")
+				//validationErrors = append(validationErrors, "automount of service account not allowed")
+				patches = append(patches, fmt.Sprintf(`{"op": "add", "path": "/spec/automountServiceAccountToken", "value": "%s"}`, "false"))
 			}
 		} else if automountServiceAccountToken == "non-default" {
 			if doesAutomountServiceAccountToken(&pod) && pod.Spec.ServiceAccountName == "default" {
-				validationErrors = append(validationErrors, "automount of service account 'default' not allowed")
+				//validationErrors = append(validationErrors, "automount of service account not allowed")
+				patches = append(patches, fmt.Sprintf(`{"op": "add", "path": "/spec/automountServiceAccountToken", "value": "%s"}`, "false"))
 			}
 		}
 	}

--- a/pkg/admission/karydia/karydia.go
+++ b/pkg/admission/karydia/karydia.go
@@ -163,9 +163,8 @@ func secureAutomountServiceAccountToken(pod corev1.Pod, annotation string, patch
 		}
 	} else if annotation == "remove-default" {
 		if automountServiceAccountTokenUndefined(&pod) && pod.Spec.ServiceAccountName == "default" {
-			patches = append(patches, fmt.Sprintf(`{"op": "add", "path": "/spec/automountServiceAccountToken", "value": "%s"}`, "false"))
-			patches = append(patches, fmt.Sprintf(`{"op": "remove", "path": "/spec/ServiceAccount"}`))
-			patches = append(patches, fmt.Sprintf(`{"op": "remove", "path": "/spec/ServiceAccountName"}`))
+			patches = append(patches, fmt.Sprintf(`{"op": "add", "path": "/spec/automountServiceAccountToken", "value": %s}`, "false"))
+			patches = append(patches, fmt.Sprintf(`{"op": "remove", "path": "/spec/serviceAccountName"}`))
 			for i, v := range pod.Spec.Volumes {
 				if strings.HasPrefix(v.Name, "default-token-") {
 					patches = append(patches, fmt.Sprintf(`{"op": "remove", "path": "/spec/volumes/%d"}`, i))
@@ -174,7 +173,7 @@ func secureAutomountServiceAccountToken(pod corev1.Pod, annotation string, patch
 			for i, c := range pod.Spec.Containers {
 				for j, v := range c.VolumeMounts {
 					if strings.HasPrefix(v.Name, "default-token-") {
-						patches = append(patches, fmt.Sprintf(`{"op": "remove", "path": "/spec/containers/%d/VolumeMounts/%d"}`, i, j))
+						patches = append(patches, fmt.Sprintf(`{"op": "remove", "path": "/spec/containers/%d/volumeMounts/%d"}`, i, j))
 					}
 				}
 			}

--- a/pkg/admission/karydia/karydia.go
+++ b/pkg/admission/karydia/karydia.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"k8s.io/api/admission/v1beta1"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
@@ -28,14 +29,11 @@ import (
 	"github.com/karydia/karydia/pkg/k8sutil/scheme"
 )
 
-var (
-	resourcePod = metav1.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
-	kindPod     = metav1.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}
-)
+var resourcePod = metav1.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
+var kindPod = metav1.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}
 
 type KarydiaAdmission struct {
-	logger *logrus.Logger
-
+	logger        *logrus.Logger
 	kubeClientset *kubernetes.Clientset
 }
 
@@ -48,120 +46,66 @@ func New(config *Config) (*KarydiaAdmission, error) {
 	logger.Level = logrus.InfoLevel
 
 	return &KarydiaAdmission{
-		logger: logger,
-
+		logger:        logger,
 		kubeClientset: config.KubeClientset,
 	}, nil
 }
 
 func (k *KarydiaAdmission) Admit(ar v1beta1.AdmissionReview, mutationAllowed bool) *v1beta1.AdmissionResponse {
-	if ignore, err := shouldIgnore(ar); err != nil {
-		k.logger.Errorf("failed to determine if admission request should be ignored: %v", err)
-		return &v1beta1.AdmissionResponse{
-			Allowed: true,
-		}
-	} else if ignore {
-		return &v1beta1.AdmissionResponse{
-			Allowed: true,
-		}
+	if shouldIgnoreEvent(ar) {
+		return k8sutil.AllowAdmissionResponse()
 	}
-
-	var response *v1beta1.AdmissionResponse
 
 	if ar.Request.Kind == kindPod && ar.Request.Resource == resourcePod {
-		response = k.AdmitPod(ar, mutationAllowed)
-	} else {
-		response = &v1beta1.AdmissionResponse{
-			Allowed: true,
-		}
+		return k.AdmitPod(*ar.Request, mutationAllowed)
 	}
 
-	return response
+	return k8sutil.AllowAdmissionResponse()
 }
 
-func (k *KarydiaAdmission) AdmitPod(ar v1beta1.AdmissionReview, mutationAllowed bool) *v1beta1.AdmissionResponse {
+func (k *KarydiaAdmission) AdmitPod(admissionRequest v1beta1.AdmissionRequest, mutationAllowed bool) *v1beta1.AdmissionResponse {
 	var patches, validationErrors []string
 
-	raw := ar.Request.Object.Raw
-	pod := corev1.Pod{}
-	deserializer := scheme.Codecs.UniversalDeserializer()
-	if _, _, err := deserializer.Decode(raw, nil, &pod); err != nil {
-		e := fmt.Errorf("failed to decode object: %v", err)
-		k.logger.Errorf("%v", e)
-		return k8sutil.ErrToAdmissionResponse(e)
-	}
+	raw := admissionRequest.Object.Raw
 
-	namespaceRequest := ar.Request.Namespace
-	if namespaceRequest == "" {
-		e := fmt.Errorf("received request with empty namespace")
-		k.logger.Errorf("%v", e)
-		return k8sutil.ErrToAdmissionResponse(e)
-	}
-	namespace, err := k.kubeClientset.CoreV1().Namespaces().Get(namespaceRequest, metav1.GetOptions{})
+	pod, err := decodePod(raw)
 	if err != nil {
-		e := fmt.Errorf("failed to determine pod's namespace: %v", err)
-		k.logger.Errorf("%v", e)
-		return k8sutil.ErrToAdmissionResponse(e)
+		k.logger.Errorf("failed to decode object: %v", err)
+		return k8sutil.ErrToAdmissionResponse(err)
 	}
 
-	automountServiceAccountToken, doCheck := namespace.ObjectMeta.Annotations["karydia.gardener.cloud/automountServiceAccountToken"]
-	if doCheck {
-		patches, validationErrors = secureAutomountServiceAccountToken(pod, automountServiceAccountToken, patches, validationErrors)
+	namespace, err := k.getNamespaceFromAdmissionRequest(admissionRequest)
+	if err != nil {
+		k.logger.Errorf("%v", err)
+		return k8sutil.ErrToAdmissionResponse(err)
 	}
 
-	seccompProfile, doCheck := namespace.ObjectMeta.Annotations["karydia.gardener.cloud/seccompProfile"]
-	if doCheck {
-		seccompPod, ok := pod.ObjectMeta.Annotations["seccomp.security.alpha.kubernetes.io/pod"]
-		if !ok && mutationAllowed {
-			if len(pod.ObjectMeta.Annotations) == 0 {
-				// If no annotation object exists yet, we have
-				// to create it. Otherwise we will encounter
-				// the following error:
-				// 'jsonpatch add operation does not apply: doc is missing path: "/metadata/annotations..."'
-				patches = append(patches, fmt.Sprintf(`{"op": "add", "path": "/metadata/annotations", "value": {"%s": "%s"}}`, "seccomp.security.alpha.kubernetes.io/pod", seccompProfile))
-			} else {
-				patches = append(patches, fmt.Sprintf(`{"op": "add", "path": "/metadata/annotations/%s", "value": "%s"}`, "seccomp.security.alpha.kubernetes.io~1pod", seccompProfile))
-			}
-		} else if seccompPod != seccompProfile {
-			validationErrorMsg := fmt.Sprintf("seccomp profile ('seccomp.security.alpha.kubernetes.io/pod') must be '%s'", seccompProfile)
-			validationErrors = append(validationErrors, validationErrorMsg)
-		}
+	automountServiceAccountToken, annotated := namespace.ObjectMeta.Annotations["karydia.gardener.cloud/automountServiceAccountToken"]
+	if annotated {
+		patches, validationErrors = admitServiceAccountToken(*pod, automountServiceAccountToken, patches, validationErrors)
 	}
 
-	if len(validationErrors) > 0 {
-		return &v1beta1.AdmissionResponse{
-			Allowed: false,
-			Result: &metav1.Status{
-				Message: fmt.Sprintf("%+v", validationErrors),
-			},
-		}
+	seccompProfile, annotated := namespace.ObjectMeta.Annotations["karydia.gardener.cloud/seccompProfile"]
+	if annotated {
+		patches, validationErrors = admitSeccompProfile(*pod, seccompProfile, mutationAllowed, patches, validationErrors)
 	}
 
-	response := &v1beta1.AdmissionResponse{
-		Allowed: true,
-	}
-
-	if len(patches) > 0 {
-		patchesStr := strings.Join(patches, ",")
-		patchType := v1beta1.PatchTypeJSONPatch
-
-		response.Patch = []byte(fmt.Sprintf("[%s]", patchesStr))
-		response.PatchType = &patchType
-	}
-
-	return response
+	return admitResponse(patches, validationErrors)
 }
 
-func secureAutomountServiceAccountToken(pod corev1.Pod, annotation string, patches []string, errors []string) ([]string, []string) {
+func admitServiceAccountToken(pod corev1.Pod, annotation string, patches []string, validationErrors []string) ([]string, []string) {
 	if annotation == "forbidden" {
+		// Validating webhook
 		if automountServiceAccountTokenUndefined(&pod) {
-			errors = append(errors, "automount of service account not allowed")
+			validationErrors = append(validationErrors, "automount of service account not allowed")
 		}
 	} else if annotation == "non-default" {
+		// Validating webhook
 		if automountServiceAccountTokenUndefined(&pod) && pod.Spec.ServiceAccountName == "default" {
-			errors = append(errors, "automount of service account 'default' not allowed")
+			validationErrors = append(validationErrors, "automount of service account 'default' not allowed")
 		}
 	} else if annotation == "remove-default" {
+		// Mutating webhook
 		if automountServiceAccountTokenUndefined(&pod) && pod.Spec.ServiceAccountName == "default" {
 			patches = append(patches, fmt.Sprintf(`{"op": "add", "path": "/spec/automountServiceAccountToken", "value": %s}`, "false"))
 			patches = append(patches, fmt.Sprintf(`{"op": "remove", "path": "/spec/serviceAccountName"}`))
@@ -179,25 +123,69 @@ func secureAutomountServiceAccountToken(pod corev1.Pod, annotation string, patch
 			}
 		}
 	}
-	fmt.Printf("Got %d patches", len(patches))
-	return patches, errors
+	return patches, validationErrors
 }
 
-func doesAutomountServiceAccountToken(pod *corev1.Pod) bool {
-	return pod.Spec.AutomountServiceAccountToken == nil || *pod.Spec.AutomountServiceAccountToken
+func admitSeccompProfile(pod corev1.Pod, seccompProfile string, mutationAllowed bool, patches []string, validationErrors []string) ([]string, []string) {
+	seccompPod, ok := pod.ObjectMeta.Annotations["seccomp.security.alpha.kubernetes.io/pod"]
+	if !ok && mutationAllowed {
+		if len(pod.ObjectMeta.Annotations) == 0 {
+			// If no annotation object exists yet, we have
+			// to create it. Otherwise we will encounter
+			// the following error:
+			// 'jsonpatch add operation does not apply: doc is missing path: "/metadata/annotations..."'
+			patches = append(patches, fmt.Sprintf(`{"op": "add", "path": "/metadata/annotations", "value": {"%s": "%s"}}`, "seccomp.security.alpha.kubernetes.io/pod", seccompProfile))
+		} else {
+			patches = append(patches, fmt.Sprintf(`{"op": "add", "path": "/metadata/annotations/%s", "value": "%s"}`, "seccomp.security.alpha.kubernetes.io~1pod", seccompProfile))
+		}
+	} else if seccompPod != seccompProfile {
+		validationErrorMsg := fmt.Sprintf("seccomp profile ('seccomp.security.alpha.kubernetes.io/pod') must be '%s'", seccompProfile)
+		validationErrors = append(validationErrors, validationErrorMsg)
+	}
+	return patches, validationErrors
 }
 
 func automountServiceAccountTokenUndefined(pod *corev1.Pod) bool {
 	return pod.Spec.AutomountServiceAccountToken == nil
 }
 
-func shouldIgnore(ar v1beta1.AdmissionReview) (bool, error) {
+func (k *KarydiaAdmission) getNamespaceFromAdmissionRequest(ar v1beta1.AdmissionRequest) (*v1.Namespace, error) {
+	namespaceRequest := ar.Namespace
+	if namespaceRequest == "" {
+		e := fmt.Errorf("received request with empty namespace")
+		return nil, e
+	}
+	namespace, err := k.kubeClientset.CoreV1().Namespaces().Get(namespaceRequest, metav1.GetOptions{})
+	if err != nil {
+		e := fmt.Errorf("failed to determine pod's namespace: %v", err)
+		return nil, e
+	}
+	return namespace, nil
+}
+
+func admitResponse(patches []string, validationErrors []string) *v1beta1.AdmissionResponse {
+	if len(validationErrors) > 0 {
+		return k8sutil.ValidationErrorAdmissionResponse(validationErrors)
+	}
+	return k8sutil.MutatingAdmissionResponse(patches)
+}
+
+func decodePod(raw []byte) (*corev1.Pod, error) {
+	pod := &corev1.Pod{}
+	deserializer := scheme.Codecs.UniversalDeserializer()
+	if _, _, err := deserializer.Decode(raw, nil, pod); err != nil {
+		return nil, err
+	}
+	return pod, nil
+}
+
+func shouldIgnoreEvent(ar v1beta1.AdmissionReview) bool {
 	// Right now we only care about 'CREATE' events. Needs to be
 	// updated depending on the kind of admission requests that
 	// `KarydiaAdmission` should handle in this package.
 	// https://github.com/kubernetes/api/blob/kubernetes-1.12.2/admission/v1beta1/types.go#L118-L127
 	if ar.Request.Operation != v1beta1.Create {
-		return true, nil
+		return true
 	}
-	return false, nil
+	return false
 }

--- a/pkg/admission/karydia/karydia_test.go
+++ b/pkg/admission/karydia/karydia_test.go
@@ -46,8 +46,8 @@ func TestMutatePodWithRemoveDefaultAnnotation(t *testing.T) {
 	pod.Spec.Containers = append([]corev1.Container{}, corev1.Container{Name: "first-container", VolumeMounts: mounts})
 
 	patches, validationErrors = secureAutomountServiceAccountToken(pod, "remove-default", patches, validationErrors)
-	if len(patches) != 5 {
-		t.Errorf("expected 5 patches but got: %+v", patches)
+	if len(patches) != 4 {
+		t.Errorf("expected 4 patches but got: %+v", patches)
 	}
 	if len(validationErrors) != 0 {
 		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)

--- a/pkg/admission/karydia/karydia_test.go
+++ b/pkg/admission/karydia/karydia_test.go
@@ -1,0 +1,31 @@
+// Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package karydia
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestMutatePodWithAnnotation(t *testing.T) {
+	pod := corev1.Pod{}
+	var patches []string
+
+	patches = secureAutomountServiceAccountToken(pod, "forbidden", patches)
+	if len(patches) != 2 {
+		t.Errorf("expected 2 patches but got: %+v", patches)
+	}
+}

--- a/pkg/admission/karydia/karydia_test.go
+++ b/pkg/admission/karydia/karydia_test.go
@@ -20,6 +20,67 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+// kubectl annotate ns default karydia.gardener.cloud/automountServiceAccountToken=remove-default
+func TestMutatePodWithRemoveDefaultAnnotation(t *testing.T) {
+	pod := corev1.Pod{}
+	var patches []string
+	var validationErrors []string
+
+	pod.Spec.ServiceAccountName = "default"
+	pod.Spec.Volumes = append([]corev1.Volume{}, corev1.Volume{Name: "default-token-abcd", VolumeSource: corev1.VolumeSource{}})
+	mounts := append([]corev1.VolumeMount{}, corev1.VolumeMount{Name: "default-token-abcd"})
+	pod.Spec.Containers = append([]corev1.Container{}, corev1.Container{Name: "first-container", VolumeMounts: mounts})
+
+	patches, validationErrors = secureAutomountServiceAccountToken(pod, "remove-default", patches, validationErrors)
+	if len(patches) != 4 {
+		t.Errorf("expected 4 patches but got: %+v", patches)
+	}
+	if len(validationErrors) != 0 {
+		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
+	}
+}
+
+func TestMutatePodWithRemoveDefaultAnnotationNonDefaultServiceAccount(t *testing.T) {
+	pod := corev1.Pod{}
+	var patches []string
+	var validationErrors []string
+
+	pod.Spec.ServiceAccountName = "test"
+	pod.Spec.Volumes = append([]corev1.Volume{}, corev1.Volume{Name: "test-token-abcd", VolumeSource: corev1.VolumeSource{}})
+	mounts := append([]corev1.VolumeMount{}, corev1.VolumeMount{Name: "test-token-abcd"})
+	pod.Spec.Containers = append([]corev1.Container{}, corev1.Container{Name: "first-container", VolumeMounts: mounts})
+
+	patches, validationErrors = secureAutomountServiceAccountToken(pod, "remove-default", patches, validationErrors)
+	if len(patches) != 0 {
+		t.Errorf("expected 0 patches but got: %+v", patches)
+	}
+	if len(validationErrors) != 0 {
+		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
+	}
+}
+
+func TestMutatePodWithRemoveDefaultAnnotationMultipleVolumes(t *testing.T) {
+	pod := corev1.Pod{}
+	var patches []string
+	var validationErrors []string
+
+	pod.Spec.ServiceAccountName = "default"
+	pod.Spec.Volumes = append([]corev1.Volume{}, corev1.Volume{Name: "default-token-abcd", VolumeSource: corev1.VolumeSource{}})
+	pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{Name: "test-token-abcd", VolumeSource: corev1.VolumeSource{}})
+	mounts := append([]corev1.VolumeMount{}, corev1.VolumeMount{Name: "default-token-abcd"})
+	mounts = append(mounts, corev1.VolumeMount{Name: "test-token-abcd"})
+	pod.Spec.Containers = append([]corev1.Container{}, corev1.Container{Name: "first-container", VolumeMounts: mounts})
+
+	patches, validationErrors = secureAutomountServiceAccountToken(pod, "remove-default", patches, validationErrors)
+	if len(patches) != 4 {
+		t.Errorf("expected 4 patches but got: %+v", patches)
+	}
+	if len(validationErrors) != 0 {
+		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
+	}
+}
+
+//kubectl annotate ns default karydia.gardener.cloud/automountServiceAccountToken=forbidden
 func TestValidatePodWithForbiddentAnnotation(t *testing.T) {
 	pod := corev1.Pod{}
 	var patches []string
@@ -35,25 +96,8 @@ func TestValidatePodWithForbiddentAnnotation(t *testing.T) {
 		t.Errorf("expected 1 validationErrors but got: %+v", validationErrors)
 	}
 }
-func TestMutatePodWithRemoveDefaultAnnotation(t *testing.T) {
-	pod := corev1.Pod{}
-	var patches []string
-	var validationErrors []string
 
-	pod.Spec.ServiceAccountName = "default"
-	pod.Spec.Volumes = append([]corev1.Volume{}, corev1.Volume{Name: "default-token-abcd", VolumeSource: corev1.VolumeSource{}})
-	mounts := append([]corev1.VolumeMount{}, corev1.VolumeMount{Name: "default-token-1234"})
-	pod.Spec.Containers = append([]corev1.Container{}, corev1.Container{Name: "first-container", VolumeMounts: mounts})
-
-	patches, validationErrors = secureAutomountServiceAccountToken(pod, "remove-default", patches, validationErrors)
-	if len(patches) != 4 {
-		t.Errorf("expected 4 patches but got: %+v", patches)
-	}
-	if len(validationErrors) != 0 {
-		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
-	}
-}
-
+//kubectl annotate ns default karydia.gardener.cloud/automountServiceAccountToken=non-default
 func TestValidatePodWithNonDefaultAnnotation(t *testing.T) {
 	pod := corev1.Pod{}
 	var patches []string
@@ -66,5 +110,20 @@ func TestValidatePodWithNonDefaultAnnotation(t *testing.T) {
 	}
 	if len(validationErrors) != 1 {
 		t.Errorf("expected 1 validationErrors but got: %+v", validationErrors)
+	}
+}
+
+func TestValidatePodWithNonDefaultAnnotationNonDefaultServiceAccount(t *testing.T) {
+	pod := corev1.Pod{}
+	var patches []string
+	var validationErrors []string
+
+	pod.Spec.ServiceAccountName = "test"
+	patches, validationErrors = secureAutomountServiceAccountToken(pod, "non-default", patches, validationErrors)
+	if len(patches) != 0 {
+		t.Errorf("expected 0 patches but got: %+v", patches)
+	}
+	if len(validationErrors) != 0 {
+		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
 	}
 }

--- a/pkg/admission/karydia/karydia_test.go
+++ b/pkg/admission/karydia/karydia_test.go
@@ -31,7 +31,7 @@ func TestMutatePodWithRemoveDefaultAnnotation(t *testing.T) {
 	mounts := append([]corev1.VolumeMount{}, corev1.VolumeMount{Name: "default-token-abcd"})
 	pod.Spec.Containers = append([]corev1.Container{}, corev1.Container{Name: "first-container", VolumeMounts: mounts})
 
-	patches, validationErrors = secureAutomountServiceAccountToken(pod, "remove-default", patches, validationErrors)
+	patches, validationErrors = admitServiceAccountToken(pod, "remove-default", patches, validationErrors)
 	if len(patches) != 4 {
 		t.Errorf("expected 4 patches but got: %+v", patches)
 	}
@@ -50,7 +50,7 @@ func TestMutatePodWithRemoveDefaultAnnotationNonDefaultServiceAccount(t *testing
 	mounts := append([]corev1.VolumeMount{}, corev1.VolumeMount{Name: "test-token-abcd"})
 	pod.Spec.Containers = append([]corev1.Container{}, corev1.Container{Name: "first-container", VolumeMounts: mounts})
 
-	patches, validationErrors = secureAutomountServiceAccountToken(pod, "remove-default", patches, validationErrors)
+	patches, validationErrors = admitServiceAccountToken(pod, "remove-default", patches, validationErrors)
 	if len(patches) != 0 {
 		t.Errorf("expected 0 patches but got: %+v", patches)
 	}
@@ -71,7 +71,7 @@ func TestMutatePodWithRemoveDefaultAnnotationMultipleVolumes(t *testing.T) {
 	mounts = append(mounts, corev1.VolumeMount{Name: "test-token-abcd"})
 	pod.Spec.Containers = append([]corev1.Container{}, corev1.Container{Name: "first-container", VolumeMounts: mounts})
 
-	patches, validationErrors = secureAutomountServiceAccountToken(pod, "remove-default", patches, validationErrors)
+	patches, validationErrors = admitServiceAccountToken(pod, "remove-default", patches, validationErrors)
 	if len(patches) != 4 {
 		t.Errorf("expected 4 patches but got: %+v", patches)
 	}
@@ -88,7 +88,7 @@ func TestValidatePodWithForbiddentAnnotation(t *testing.T) {
 
 	pod.Spec.ServiceAccountName = "default"
 
-	patches, validationErrors = secureAutomountServiceAccountToken(pod, "forbidden", patches, validationErrors)
+	patches, validationErrors = admitServiceAccountToken(pod, "forbidden", patches, validationErrors)
 	if len(patches) != 0 {
 		t.Errorf("expected 0 patches but got: %+v", patches)
 	}
@@ -104,7 +104,7 @@ func TestValidatePodWithNonDefaultAnnotation(t *testing.T) {
 	var validationErrors []string
 
 	pod.Spec.ServiceAccountName = "default"
-	patches, validationErrors = secureAutomountServiceAccountToken(pod, "non-default", patches, validationErrors)
+	patches, validationErrors = admitServiceAccountToken(pod, "non-default", patches, validationErrors)
 	if len(patches) != 0 {
 		t.Errorf("expected 0 patches but got: %+v", patches)
 	}
@@ -119,7 +119,7 @@ func TestValidatePodWithNonDefaultAnnotationNonDefaultServiceAccount(t *testing.
 	var validationErrors []string
 
 	pod.Spec.ServiceAccountName = "test"
-	patches, validationErrors = secureAutomountServiceAccountToken(pod, "non-default", patches, validationErrors)
+	patches, validationErrors = admitServiceAccountToken(pod, "non-default", patches, validationErrors)
 	if len(patches) != 0 {
 		t.Errorf("expected 0 patches but got: %+v", patches)
 	}

--- a/pkg/admission/karydiasecuritypolicy/pod.go
+++ b/pkg/admission/karydiasecuritypolicy/pod.go
@@ -103,11 +103,13 @@ func validatePod(policy *v1alpha1.KarydiaSecurityPolicy, pod *corev1.Pod) ([]str
 
 	if policy.Spec.Pod.AutomountServiceAccountToken == "forbidden" {
 		if doesAutomountServiceAccountToken(pod) {
-			validationErrors = append(validationErrors, "automount of service account not allowed")
+			//validationErrors = append(validationErrors, "automount of service account not allowed")
+			patches = append(patches, fmt.Sprintf(`{"op": "add", "path": "/spec/automountServiceAccountToken", "value": "%s"}`, "false"))
 		}
 	} else if policy.Spec.Pod.AutomountServiceAccountToken == "non-default" {
 		if doesAutomountServiceAccountToken(pod) && pod.Spec.ServiceAccountName == "default" {
-			validationErrors = append(validationErrors, "automount of service account 'default' not allowed")
+			//validationErrors = append(validationErrors, "automount of service account 'default' not allowed")
+			patches = append(patches, fmt.Sprintf(`{"op": "add", "path": "/spec/automountServiceAccountToken", "value": "%s"}`, "false"))
 		}
 	}
 

--- a/pkg/admission/karydiasecuritypolicy/pod.go
+++ b/pkg/admission/karydiasecuritypolicy/pod.go
@@ -103,13 +103,11 @@ func validatePod(policy *v1alpha1.KarydiaSecurityPolicy, pod *corev1.Pod) ([]str
 
 	if policy.Spec.Pod.AutomountServiceAccountToken == "forbidden" {
 		if doesAutomountServiceAccountToken(pod) {
-			//validationErrors = append(validationErrors, "automount of service account not allowed")
-			patches = append(patches, fmt.Sprintf(`{"op": "add", "path": "/spec/automountServiceAccountToken", "value": "%s"}`, "false"))
+			validationErrors = append(validationErrors, "automount of service account not allowed")
 		}
 	} else if policy.Spec.Pod.AutomountServiceAccountToken == "non-default" {
 		if doesAutomountServiceAccountToken(pod) && pod.Spec.ServiceAccountName == "default" {
-			//validationErrors = append(validationErrors, "automount of service account 'default' not allowed")
-			patches = append(patches, fmt.Sprintf(`{"op": "add", "path": "/spec/automountServiceAccountToken", "value": "%s"}`, "false"))
+			validationErrors = append(validationErrors, "automount of service account 'default' not allowed")
 		}
 	}
 

--- a/pkg/admission/karydiasecuritypolicy/pod_seccomp_test.go
+++ b/pkg/admission/karydiasecuritypolicy/pod_seccomp_test.go
@@ -36,15 +36,14 @@ func TestValidatePod(t *testing.T) {
 	policy := &v1alpha1.KarydiaSecurityPolicy{
 		Spec: v1alpha1.KarydiaSecurityPolicySpec{
 			Pod: v1alpha1.Pod{
-				AutomountServiceAccountToken: "forbidden",
-				SeccompProfile:               "docker/default",
+				SeccompProfile: "docker/default",
 			},
 		},
 	}
 
 	patches, validationErrors = validatePod(policy, pod)
-	if len(validationErrors) != 1 {
-		t.Errorf("expected 1 validation errors but got: %+v", validationErrors)
+	if len(validationErrors) != 0 {
+		t.Errorf("expected 0 validation errors but got: %+v", validationErrors)
 	}
 	if len(patches) != 1 {
 		t.Errorf("expected 1 patch but got: %+v", patches)
@@ -55,7 +54,7 @@ func TestValidatePod(t *testing.T) {
 	}
 
 	patches, validationErrors = validatePod(policy, pod)
-	if len(validationErrors) != 2 {
+	if len(validationErrors) != 1 {
 		t.Errorf("expected 2 validation errors but got: %+v", validationErrors)
 	}
 	if len(patches) != 0 {

--- a/pkg/admission/karydiasecuritypolicy/pod_seccomp_test.go
+++ b/pkg/admission/karydiasecuritypolicy/pod_seccomp_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/karydia/karydia/pkg/apis/karydia/v1alpha1"
 )
 
-func TestValidatePod(t *testing.T) {
+func TestValidatePodSeccomp(t *testing.T) {
 	pod := &corev1.Pod{}
 
 	patches, validationErrors := validatePod(&v1alpha1.KarydiaSecurityPolicy{}, pod)

--- a/pkg/admission/karydiasecuritypolicy/pod_service_token_test.go
+++ b/pkg/admission/karydiasecuritypolicy/pod_service_token_test.go
@@ -1,0 +1,51 @@
+// Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package karydiasecuritypolicy
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/karydia/karydia/pkg/apis/karydia/v1alpha1"
+)
+
+func TestMutatePod(t *testing.T) {
+	pod := &corev1.Pod{}
+
+	patches, validationErrors := validatePod(&v1alpha1.KarydiaSecurityPolicy{}, pod)
+	if len(validationErrors) != 0 {
+		t.Errorf("expected 0 validation errors but got: %+v", validationErrors)
+	}
+	if len(patches) != 0 {
+		t.Errorf("expected no patches but got: %+v", patches)
+	}
+
+	policy := &v1alpha1.KarydiaSecurityPolicy{
+		Spec: v1alpha1.KarydiaSecurityPolicySpec{
+			Pod: v1alpha1.Pod{
+				AutomountServiceAccountToken: "forbidden",
+			},
+		},
+	}
+
+	patches, validationErrors = validatePod(policy, pod)
+	if len(validationErrors) != 0 {
+		t.Errorf("expected 0 validation errors but got: %+v", validationErrors)
+	}
+	if len(patches) != 1 {
+		t.Errorf("expected 1 patch but got: %+v", patches)
+	}
+}

--- a/pkg/admission/karydiasecuritypolicy/pod_service_token_test.go
+++ b/pkg/admission/karydiasecuritypolicy/pod_service_token_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/karydia/karydia/pkg/apis/karydia/v1alpha1"
 )
 
-func TestMutatePod(t *testing.T) {
+func TestMutatePodServiceToken(t *testing.T) {
 	pod := &corev1.Pod{}
 
 	patches, validationErrors := validatePod(&v1alpha1.KarydiaSecurityPolicy{}, pod)

--- a/pkg/admission/karydiasecuritypolicy/pod_service_token_test.go
+++ b/pkg/admission/karydiasecuritypolicy/pod_service_token_test.go
@@ -42,10 +42,10 @@ func TestMutatePodServiceToken(t *testing.T) {
 	}
 
 	patches, validationErrors = validatePod(policy, pod)
-	if len(validationErrors) != 0 {
-		t.Errorf("expected 0 validation errors but got: %+v", validationErrors)
+	if len(validationErrors) != 1 {
+		t.Errorf("expected 1 validation errors but got: %+v", validationErrors)
 	}
-	if len(patches) != 1 {
-		t.Errorf("expected 1 patch but got: %+v", patches)
+	if len(patches) != 0 {
+		t.Errorf("expected 0 patch but got: %+v", patches)
 	}
 }

--- a/pkg/k8sutil/admission.go
+++ b/pkg/k8sutil/admission.go
@@ -15,6 +15,9 @@
 package k8sutil
 
 import (
+	"fmt"
+	"strings"
+
 	"k8s.io/api/admission/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -25,5 +28,36 @@ func ErrToAdmissionResponse(err error) *v1beta1.AdmissionResponse {
 		Result: &metav1.Status{
 			Message: err.Error(),
 		},
+	}
+}
+
+func ValidationErrorAdmissionResponse(validationErrors []string) *v1beta1.AdmissionResponse {
+	return &v1beta1.AdmissionResponse{
+		Allowed: false,
+		Result: &metav1.Status{
+			Message: fmt.Sprintf("%+v", validationErrors),
+		},
+	}
+}
+
+func MutatingAdmissionResponse(patches []string) *v1beta1.AdmissionResponse {
+	response := &v1beta1.AdmissionResponse{
+		Allowed: true,
+	}
+
+	if len(patches) > 0 {
+		patchesStr := strings.Join(patches, ",")
+		patchType := v1beta1.PatchTypeJSONPatch
+
+		response.Patch = []byte(fmt.Sprintf("[%s]", patchesStr))
+		response.PatchType = &patchType
+	}
+
+	return response
+}
+
+func AllowAdmissionResponse() *v1beta1.AdmissionResponse {
+	return &v1beta1.AdmissionResponse{
+		Allowed: true,
 	}
 }

--- a/tests/e2e/karydia_admission_test.go
+++ b/tests/e2e/karydia_admission_test.go
@@ -47,7 +47,6 @@ func TestAutomountServiceAccountToken(t *testing.T) {
 			Namespace: ns,
 		},
 		Spec: corev1.PodSpec{
-			AutomountServiceAccountToken: &automountServiceAccountToken,
 			Containers: []corev1.Container{
 				{
 					Name:  "nginx",


### PR DESCRIPTION
### Description
Introduces a new option `remove-default` for `karydia.gardener.cloud/automountServiceAccountToken`. When this option is configured for a namespace, all pods that do not explicitly require the default service account do not mount the default token. The mutating hook removes the default service account token volume mount for each container and pod definition. 

Additionally, unit-tests for the existing options `non-default` and `forbidden` were implemented.

Adressing issue #55.

### Checklist
Before submitting this PR, please make sure:

- [x] Your code builds clean with `make test`
- [x] You have added unit tests
- [x] You have documented new or changed features