### PR TITLE
manifests/rbac: allow karydia to list {cluster,}role{s,bindings}

### DIFF
--- a/manifests/rbac.yml
+++ b/manifests/rbac.yml
@@ -87,6 +87,32 @@ roleRef:
 
 ---
 
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: karydia-view-roles
+rules:
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["clusterroles", "clusterrolebindings", "roles", "rolebindings"]
+  verbs: ["list"]
+
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: karydia-view-roles
+subjects:
+- kind: ServiceAccount
+  namespace: kube-system
+  name: karydia
+roleRef:
+  kind: ClusterRole
+  name: karydia-view-roles
+  apiGroup: rbac.authorization.k8s.io
+
+---
+
 # Define role for OPA/kube-mgmt to update configmaps with policy status.
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
The KarydiaSecurityPolicy admission handler needs permission to list
{cluster,}role{s,bindings} for KSPs to work. If not given, it cannot
list the available bindings in order to determine the KSPs to check for
the currrent user.

```
E0410 12:44:48.711578       1 reflector.go:134] k8s.io/client-go/informers/factory.go:131: Failed to list *v1.ClusterRoleBinding: clusterrolebindings.rbac.authorization.k8s.io is forbidden: User "system:serviceaccount:kube-system:karydia" cannot list resource "clusterrolebindings" in API group "rbac.authorization.k8s.io" at the cluster scope
E0410 12:44:48.742234       1 reflector.go:134] k8s.io/client-go/informers/factory.go:131: Failed to list *v1.ClusterRole: clusterroles.rbac.authorization.k8s.io is forbidden: User "system:serviceaccount:kube-system:karydia" cannot list resource "clusterroles" in API group "rbac.authorization.k8s.io" at the cluster scope
E0410 12:44:48.755163       1 reflector.go:134] k8s.io/client-go/informers/factory.go:131: Failed to list *v1.Role: roles.rbac.authorization.k8s.io is forbidden: User "system:serviceaccount:kube-system:karydia" cannot list resource "roles" in API group "rbac.authorization.k8s.io" at the cluster scope
E0410 12:44:49.711716       1 reflector.go:134] k8s.io/client-go/informers/factory.go:131: Failed to list *v1.RoleBinding: rolebindings.rbac.authorization.k8s.io is forbidden: User "system:serviceaccount:kube-system:karydia" cannot list resource "rolebindings" in API group "rbac.authorization.k8s.io" at the cluster scope
```

The default view role that we already give to karydia is not enough:

"Allows read-only access to see most objects in a namespace. It does not
allow viewing roles or rolebindings." [1]

Thus we expliclity have to allow listing of those resources for KSP
authz to work.

I guess we didn't notice before because when we did the change in
b16bfba8c3a203ef1da9cb5ce888a38faac07362 KSPs were already disabled by
default and nobody checked since - until now. And even before that we
used cluster-admin and had all privileges.

[1] https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles
