### PR TITLE
[Test] E2E tests for service token pod webhook

### DIFF
--- a/tests/e2e/framework/framework.go
+++ b/tests/e2e/framework/framework.go
@@ -57,6 +57,21 @@ func Setup(server, kubeconfig, namespace string) (*Framework, error) {
 	}, nil
 }
 
+func (f *Framework) CreateServiceAccount(serviceAccountName string, namespace string) (*corev1.ServiceAccount, error) {
+	serviceAccount := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      serviceAccountName,
+			Namespace: namespace,
+		},
+	}
+
+	serviceAccount, err := f.KubeClientset.CoreV1().ServiceAccounts(namespace).Create(serviceAccount)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create service account: %v", err)
+	}
+	return serviceAccount, nil
+}
+
 func (f *Framework) CreateNamespace() error {
 	var objectMeta metav1.ObjectMeta
 	objectMeta.Labels = map[string]string{

--- a/tests/e2e/karydia_admission_test.go
+++ b/tests/e2e/karydia_admission_test.go
@@ -15,6 +15,7 @@
 package e2e
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -22,7 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestAutomountServiceAccountToken(t *testing.T) {
+func TestAutomountServiceAccountTokenForbidden(t *testing.T) {
 	namespace, err := f.CreateTestNamespace()
 	if err != nil {
 		t.Fatalf("failed to create test namespace: %v", err)
@@ -38,8 +39,6 @@ func TestAutomountServiceAccountToken(t *testing.T) {
 	}
 
 	ns := namespace.ObjectMeta.Name
-
-	automountServiceAccountToken := true
 
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -61,14 +60,7 @@ func TestAutomountServiceAccountToken(t *testing.T) {
 		t.Fatalf("expected pod creation to fail")
 	}
 
-	pod.Spec.AutomountServiceAccountToken = nil
-
-	_, err = f.KubeClientset.CoreV1().Pods(ns).Create(pod)
-	if err == nil {
-		t.Fatalf("expected pod creation to fail")
-	}
-
-	automountServiceAccountToken = false
+	automountServiceAccountToken := false
 	pod.Spec.AutomountServiceAccountToken = &automountServiceAccountToken
 
 	pod, err = f.KubeClientset.CoreV1().Pods(ns).Create(pod)
@@ -79,5 +71,110 @@ func TestAutomountServiceAccountToken(t *testing.T) {
 	timeout := 2 * time.Minute
 	if err := f.WaitPodRunning(pod.ObjectMeta.Namespace, pod.ObjectMeta.Name, timeout); err != nil {
 		t.Fatalf("pod never reached state running")
+	}
+
+}
+
+func TestAutomountServiceAccountTokenNonDefault(t *testing.T) {
+	namespace, err := f.CreateTestNamespace()
+	if err != nil {
+		t.Fatalf("failed to create test namespace: %v", err)
+	}
+
+	namespace.ObjectMeta.Annotations = map[string]string{
+		"karydia.gardener.cloud/automountServiceAccountToken": "non-default",
+	}
+
+	namespace, err = f.KubeClientset.CoreV1().Namespaces().Update(namespace)
+	if err != nil {
+		t.Fatalf("failed to annotate test namespace: %v", err)
+	}
+
+	ns := namespace.ObjectMeta.Name
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "karydia-e2e-test-pod",
+			Namespace: ns,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "nginx",
+					Image: "nginx",
+				},
+			},
+		},
+	}
+
+	_, err = f.KubeClientset.CoreV1().Pods(ns).Create(pod)
+	if err == nil {
+		t.Fatalf("expected pod creation to fail")
+	}
+
+	serviceAccount, err := f.CreateServiceAccount("non-default", namespace.GetName())
+	if err != nil {
+		t.Fatalf("failed to create service account: %v", err)
+	}
+
+	pod.Spec.ServiceAccountName = serviceAccount.GetName()
+	pod, err = f.KubeClientset.CoreV1().Pods(ns).Create(pod)
+	if err != nil {
+		t.Fatalf("failed to create pod: %v", err)
+	}
+
+	timeout := 2 * time.Minute
+	if err := f.WaitPodRunning(pod.ObjectMeta.Namespace, pod.ObjectMeta.Name, timeout); err != nil {
+		t.Fatalf("pod never reached state running")
+	}
+}
+
+func TestAutomountServiceAccountTokenRemoveDefault(t *testing.T) {
+	namespace, err := f.CreateTestNamespace()
+	if err != nil {
+		t.Fatalf("failed to create test namespace: %v", err)
+	}
+	namespace.ObjectMeta.Annotations = map[string]string{
+		"karydia.gardener.cloud/automountServiceAccountToken": "remove-default",
+	}
+	namespace, err = f.KubeClientset.CoreV1().Namespaces().Update(namespace)
+	if err != nil {
+		t.Fatalf("failed to annotate test namespace: %v", err)
+	}
+
+	ns := namespace.ObjectMeta.Name
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "karydia-e2e-test-pod",
+			Namespace: ns,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "nginx",
+					Image: "nginx",
+				},
+			},
+		},
+	}
+
+	pod, err = f.KubeClientset.CoreV1().Pods(ns).Create(pod)
+	if err != nil {
+		t.Fatalf("failed to create pod: %v", err)
+	}
+
+	timeout := 2 * time.Minute
+	if err := f.WaitPodRunning(pod.ObjectMeta.Namespace, pod.ObjectMeta.Name, timeout); err != nil {
+		t.Fatalf("pod never reached state running")
+	}
+
+	if pod.Spec.AutomountServiceAccountToken == nil || *pod.Spec.AutomountServiceAccountToken {
+		t.Fatalf("pod's `automountServiceAccountToken` hasn't been set to `false` by default")
+	}
+	for _, vol := range pod.Spec.Volumes {
+		if strings.HasPrefix(vol.Name, "default-token-") {
+			t.Fatalf("pod has a default service account token mounted when it should not")
+		}
 	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a PR -->

### Description
<!-- Feature description or reference to fixed issue -->
 Test `remove-default` and `non-default` options for service account token webhook.

### Checklist
Before submitting this PR, please make sure:
- [x] your code builds clean with `make test`
- [x] you have added e2e tests

<!-- Please delete options that are not relevant -->
