### PR TITLE
Enrich hotswap with ability to handle debugging

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
+.idea/
 .ci/
 bin/
 contrib/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .*.sw[po]
 
+.idea/
 bin/
 
 karydia*.pem

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,13 @@ build:
 		-ldflags "-s -X github.com/karydia/karydia.Version=$(VERSION)" \
 		cli/main.go
 
+.PHONY: build-debug
+build-debug:
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/karydia \
+		-gcflags="all=-N -l" \
+		-ldflags "-X github.com/karydia/karydia.Version=$(VERSION)" \
+		cli/main.go
+
 .PHONY: container
 container:
 	docker build -t $(IMAGE_REPO)/$(IMAGE_NAME) .
@@ -40,7 +47,11 @@ container-dev:
 
 .PHONY: deploy-dev
 deploy-dev:
-	kubectl cp bin/karydia kube-system/$(shell kubectl get pods -n=kube-system --selector=app=karydia --output=jsonpath='{.items[0].metadata.name}'):/usr/local/bin/karydia$(DEV_POSTFIX)
+	kubectl cp bin/karydia -n kube-system $(shell kubectl get pods -n=kube-system --selector=app=karydia --output=jsonpath='{.items[0].metadata.name}'):/usr/local/bin/karydia$(DEV_POSTFIX)
+
+.PHONY: debug-dev
+debug-dev:
+	kubectl port-forward -n kube-system pod/$(shell kubectl get pods -n=kube-system --selector=app=karydia --output=jsonpath='{.items[0].metadata.name}') 2345
 
 .PHONY: codegen
 codegen:

--- a/docs/devel/hotswap.md
+++ b/docs/devel/hotswap.md
@@ -17,8 +17,7 @@ Build the dev karydia container:
 make container-dev
 ```
 and push it to your docker registry.
-Adjust `manifests-dev/deployment-dev.yml` to your docker registry image manually or just use the
-next step.
+Adjust `manifests-dev/deployment-dev.yml` to your docker registry image manually or just use the next step.
 
 ## [OPTIONAL] Re-Generate the `manifests-dev/deployment-dev.yml`
 
@@ -28,8 +27,7 @@ You can use `scripts/generate-deployment-dev` to automatically re-generate the
 Two parameters are expected:
 - PROD_DOCKER_IMAGE which is the mentioned image under the karydia container spec at
 `manifests/deployment.yml` (e.g. `karydia/karydia`)
-- DEV_DOCKER_IMAGE which is the dev container image (e.g. `karydia/karydia-dev` OR your docker
-registry image from the previous step)
+- DEV_DOCKER_IMAGE which is the dev container image (e.g. `karydia/karydia-dev` OR your docker registry image from the previous step)
 ```
 scripts/generate-deployment-dev karydia/karydia karydia/karydia-dev
 ```
@@ -46,8 +44,24 @@ kubectl apply -f manifests-dev/deployment-dev.yml
 
 Develop a new feature
 
+### Live testing
+
 Build karydia and copy this new karydia go binary directly into the running cloud dev container:
 ```
 make build deploy-dev
 ```
+
+### Live debugging
+
+Build karydia with debug symbols and copy this new karydia go binary directly into the running cloud dev container:
+```
+make build-debug deploy-dev
+```
+
+Forward debug port to `localhost` via:
+```
+make debug-dev
+```
+
+Connect code debugger, e.g. from IDE, to (remote) debug port (default: `localhost:2345`)
 

--- a/manifests-dev/deployment-dev.yml
+++ b/manifests-dev/deployment-dev.yml
@@ -29,7 +29,7 @@ spec:
       serviceAccount: karydia
       containers:
       - name: karydia
-        image: karydia/karydia-dev
+        image: eu.gcr.io/gardener-project/karydia/karydia-dev
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: karydia-tls

--- a/manifests-dev/deployment-dev.yml
+++ b/manifests-dev/deployment-dev.yml
@@ -38,6 +38,10 @@ spec:
         - containerPort: 33333
         command:
         - hotswap-dev
+        - -r
+        - 'dlv --listen=:2345 --headless=true --api-version=2 --accept-multiclient
+          exec {{binPath}} --'
+        - --
         - /usr/local/bin/karydia
         - runserver
         - --tls-cert

--- a/scripts/generate-deployment-dev
+++ b/scripts/generate-deployment-dev
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 # Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,6 +16,7 @@
 
 # This script is only for development. It generates the dev deployment yaml with a dev container from the prod deployment yaml.
 # This dev deployment yaml replaces the default deployment yaml and thus should ease and speed up (local) development.
+# author: Jonas Zengerle
 
 set -e
 
@@ -23,7 +25,12 @@ PROD_IMAGE="$1"	# e.g. 'karydia/karydia'
 DEV_IMAGE="$2"	# e.g. 'karydia/karydia-dev'
 PROD_YAML='manifests/deployment.yml'
 DEV_YAML='manifests-dev/deployment-dev.yml'
-DEV_CMD_FIRST='hotswap-dev'
+DEV_CMD_FIRST=(
+  'hotswap-dev'
+  '-r'
+  "'dlv --listen=:2345 --headless=true --api-version=2 --accept-multiclient exec {{binPath}} --'"
+  '--'
+)
 DEV_CMD_BIN_LOCATION='/usr/local/bin/'
 CMD_MAIN_BIN='karydia'
 ERR_MSG_PREFIX='ERROR'
@@ -65,19 +72,32 @@ $cmd
 EOF
 )"												# get size of prod command list
     yq d -i "$DEV_YAML" "spec.template.spec.containers.$i.command"				# delete prod command list
-    yq w -i "$DEV_YAML" "spec.template.spec.containers.$i.command.0" -- "$DEV_CMD_FIRST"	# set first command of dev command list
-    for ((j=0;j<$size;j++))
+    cnt=1											# count written elements of additional dev command list
+    for ((j=0;j<${#DEV_CMD_FIRST[*]};j++))							# loop through additional dev command elements
+    do
+      yq w -i "$DEV_YAML" "spec.template.spec.containers.$i.command.$((cnt-1))" -- \
+        "${DEV_CMD_FIRST[$j]}"									# add command to dev command list
+      ((cnt++))											# increase written elements counter
+    done
+    for ((j=0;j<$size;j++))									# loop through prod command list
     do
       c="$(cat <<EOF | yq r - $j
 $cmd
 EOF
-)"												# get each command of prod command list
-      [ "$c" == "$CMD_MAIN_BIN" ] && c="$DEV_CMD_BIN_LOCATION$c"				# if command equals main binary add location
-      yq w -i "$DEV_YAML" "spec.template.spec.containers.$i.command.$((j+1))" -- "$c"		# add command to dev command list
+)"												# get element of prod command list
+      [ "$c" == "$CMD_MAIN_BIN" ] && c="$DEV_CMD_BIN_LOCATION$c"				# if element equals main binary add location
+      yq w -i "$DEV_YAML" "spec.template.spec.containers.$i.command.$((j+cnt-1))" -- "$c"	# add command to dev command list
     done
     yq d -i "$DEV_YAML" "spec.template.spec.containers.$i.livenessProbe"			# delete liveness probe for dev
   fi
 done
+
+## yq uses yaml parser which strips single and double quotes (and comments), thus, the following step is needed to keep single quotes
+## see https://github.com/mikefarah/yq/issues/19
+## replace resulting tripple single quotes (''') with just one single quote (')
+cat <<EOF > "$DEV_YAML" |
+$(cat "$DEV_YAML" | sed -e "s|'''|'|g")
+EOF
 
 ## success message
 echo "Successfully generated '$DEV_YAML'"

--- a/scripts/hotswap-dev
+++ b/scripts/hotswap-dev
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 # Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,29 +17,70 @@
 # This script is only for development. It (hot)swaps the main binary within a running dev container for a new binary.
 # This new binary could be built locally and just copied to the dev container (e.g. with 'kubectl cp'). Afterwards this script kill(s) the running
 # main binary process(es), replaces the main binary with the new one and starts it again.
+# author: Jonas Zengerle
 
 set -e
+
+# Options
+## provide the following parameters for customizing
+##   -r <command>	: use this command to run main binary instead of starting it directly
+while getopts ":r:" opt
+do
+  case $opt in
+    r)
+      RUN_CMD="$OPTARG"			# e.g. 'dlv --listen=:2345 --headless=true --api-version=2 --accept-multiclient exec {{binPath}} --'
+    ;;
+  esac
+done
+shift $((OPTIND-1))
 
 # Setup
 MAIN_BIN_PATH="$1"			# e.g. '/usr/local/bin/karydia'
 WATCH_BIN_PATH="$1-dev"			# e.g. '/usr/local/bin/karydia-dev'
 MAIN_BIN=$(basename "$MAIN_BIN_PATH")	# e.g. 'karydia'
 WATCH_BIN=$(basename "$WATCH_BIN_PATH")	# e.g. 'karydia-dev'
+MAIN_BIN_RUN_CMD="$MAIN_BIN_PATH"	# e.g. '/usr/local/bin/karydia'
 LOG_MAIN="$MAIN_BIN.log"		# e.g. 'karydia.log'
 LOG_SELF=$(basename "$0")'.log'		# e.g. 'hotswap-dev.log'
 LOG_FORMAT='%-23s\t%-4s\t%-6s\t%-11s\t%-18s\t%-8s\n'
 MAX_CYCLES=10
 
+# Templating
+## provide the following placeholder(s) for usage in run command (specified via parameter '-r')
+##   {{binPath}}	gets replaced with	path to main binary ($MAIN_BIN_PATH)
+if ! [ -z "$RUN_CMD" ]
+then
+  MAIN_BIN_RUN_CMD=$(printf '%s' "$RUN_CMD" | sed \
+    -e "s|{{binPath}}|$MAIN_BIN_PATH|g"	# replace '{{binPath}}' with path to main binary ($MAIN_BIN_PATH)
+  )
+fi
+
+# Functions
+## get IDs of processes which are using specified file passed via parameter (e.g. $1:'/usr/local/bin/karydia')
+function getPids() {
+  lsof | grep $1 |
+    while read -r name pid data
+    do
+      printf '%s\n' "$pid"
+    done
+}
+
 
 # Start
 
-## run main binary in separate process with passed parameters (e.g. $2:'runserver', $3:'--tls-cert', ...) if main binary exists otherwise exit
-[ -e "$MAIN_BIN_PATH" ] && (nohup "$MAIN_BIN_PATH" "${@:2}" > "$LOG_MAIN" &) || exit 1
+## prepare parameters for 'nohup' command
+NOHUP_UTILITY=$(echo "$MAIN_BIN_RUN_CMD" | cut -d' ' -f1)									# e.g. '/usr/local/bin/karydia'
+NOHUP_ARGUMENTS=''														# add content only if existent
+[ $(echo "$MAIN_BIN_RUN_CMD" | wc -w) -gt 1 ] && NOHUP_ARGUMENTS+=$(echo "$MAIN_BIN_RUN_CMD"' ' | cut -d' ' -f2-) || true	# e.g. '--listen=:40000 --headless=true ...'
+[ $(echo "${@:2}" | wc -w) -ge 1 ] && NOHUP_ARGUMENTS+=$(echo "${@:2}") || true							# e.g. 'runserver --tls-cert ...'
+
+## run main binary in separate process with passed parameters if main binary exists otherwise exit
+[ -e "$MAIN_BIN_PATH" ] && (nohup $NOHUP_UTILITY $NOHUP_ARGUMENTS > "$LOG_MAIN" &) || exit 1
 
 ## log activity to STDOUT and file
 touch "$LOG_SELF"
-echo "$MAIN_BIN_PATH ${@:2}" | tee "$LOG_SELF"
-printf "\n$LOG_FORMAT" 'DATE' 'TYPE' 'USER' 'FILE' 'MESSAGE' 'EVENTS' | tee -a "$LOG_SELF"
+printf '%s %s\n\n' "$NOHUP_UTILITY" "$NOHUP_ARGUMENTS" | tee "$LOG_SELF"
+printf "$LOG_FORMAT" 'DATE' 'TYPE' 'USER' 'FILE' 'MESSAGE' 'EVENTS' | tee -a "$LOG_SELF"
 
 
 # Watch
@@ -53,11 +95,15 @@ do
   then
     msg=''; cnt=1
 
+    ## if main binary file is moved connected processes are automatically adjusted to moved file (by OS), thus, the following step is needed to free file
+    ## kill / send 'SIGTERM' to these processes
+    [ "$event" == 'MOVED_TO' ] && [ ! -e "$MAIN_BIN_PATH" ] && sleep $(($MAX_CYCLES/2)) && kill $(getPids $WATCH_BIN_PATH) &> /dev/null || true
+
     ## wait till all processes (e.g. 'kubectl cp') freed watched file otherwise exit after some time
     while [[ "$(lsof | grep $WATCH_BIN_PATH)" != '' ]]; do sleep 1 && ((cnt++)) && ((cnt>$MAX_CYCLES+1)) && exit 1; done
 
-    ## kill / send 'SIGTERM' to processes who are using main binary
-    kill "$(pgrep $MAIN_BIN_PATH)" &> /dev/null || true
+    ## kill / send 'SIGTERM' to processes using main binary
+    kill $(getPids $MAIN_BIN_PATH) &> /dev/null || true
 
     msg+='killed'; cnt=1
 
@@ -67,8 +113,8 @@ do
     ## set watched file as new main binary
     mv -f "$WATCH_BIN_PATH" "$MAIN_BIN_PATH"
 
-    ## run main binary in separate process with passed parameters (e.g. $2:'runserver', $3:'--tls-cert', ...) if main binary exists otherwise exit
-    [ -e "$MAIN_BIN_PATH" ] && (nohup "$MAIN_BIN_PATH" "${@:2}" > "$LOG_MAIN" &) || exit 1
+    ## run main binary in separate process with passed parameters if main binary exists otherwise exit
+    [ -e "$MAIN_BIN_PATH" ] && (nohup $NOHUP_UTILITY $NOHUP_ARGUMENTS > "$LOG_MAIN" &) || exit 1
 
     msg+=' & restarted'; cnt=1
 


### PR DESCRIPTION
<!-- Thanks for sending a PR -->

### Description
<!-- Feature description or reference to fixed issue -->
For development it is now possible to use
- 'make build-debug' which builds the karydia binary with additional debug symbols
- 'make debug-dev' which forwards the K8s karydia cluster debug port to localhost (default: 2345) for (remote) connecting code debuggers
This should ease and speed up (local) development.
See docs/devel/hotswap.md for usage information

### Checklist
Before submitting this PR, please make sure:
- [x] you have documented new or changed features
<!-- Please delete options that are not relevant -->
