### PR TITLE
[FIX] Fix bug for remove-default option for admission hook caused by #84

### DIFF
--- a/pkg/admission/karydia/karydia.go
+++ b/pkg/admission/karydia/karydia.go
@@ -106,27 +106,24 @@ func admitServiceAccountToken(pod corev1.Pod, annotation string, mutationAllowed
 		}
 	} else if annotation == "remove-default" {
 		// Mutating webhook
-		if mutationAllowed {
 
-			if automountServiceAccountTokenUndefined(&pod) && pod.Spec.ServiceAccountName == "default" {
-				patches = append(patches, fmt.Sprintf(`{"op": "add", "path": "/spec/automountServiceAccountToken", "value": %s}`, "false"))
-				patches = append(patches, fmt.Sprintf(`{"op": "remove", "path": "/spec/serviceAccountName"}`))
-				for i, v := range pod.Spec.Volumes {
-					if strings.HasPrefix(v.Name, "default-token-") {
-						patches = append(patches, fmt.Sprintf(`{"op": "remove", "path": "/spec/volumes/%d"}`, i))
-					}
+		if automountServiceAccountTokenUndefined(&pod) && pod.Spec.ServiceAccountName == "default" {
+			patches = append(patches, fmt.Sprintf(`{"op": "add", "path": "/spec/automountServiceAccountToken", "value": %s}`, "false"))
+			patches = append(patches, fmt.Sprintf(`{"op": "remove", "path": "/spec/serviceAccountName"}`))
+			for i, v := range pod.Spec.Volumes {
+				if strings.HasPrefix(v.Name, "default-token-") {
+					patches = append(patches, fmt.Sprintf(`{"op": "remove", "path": "/spec/volumes/%d"}`, i))
 				}
-				for i, c := range pod.Spec.Containers {
-					for j, v := range c.VolumeMounts {
-						if strings.HasPrefix(v.Name, "default-token-") {
-							patches = append(patches, fmt.Sprintf(`{"op": "remove", "path": "/spec/containers/%d/volumeMounts/%d"}`, i, j))
-						}
+			}
+			for i, c := range pod.Spec.Containers {
+				for j, v := range c.VolumeMounts {
+					if strings.HasPrefix(v.Name, "default-token-") {
+						patches = append(patches, fmt.Sprintf(`{"op": "remove", "path": "/spec/containers/%d/volumeMounts/%d"}`, i, j))
 					}
 				}
 			}
-		} else {
-			validationErrors = append(validationErrors, "option 'remove-default' for  karydia.gardener.cloud/automountServiceAccountToken is only available for mutating webhooks")
 		}
+
 	}
 	return patches, validationErrors
 }

--- a/pkg/admission/karydia/service_token_test.go
+++ b/pkg/admission/karydia/service_token_test.go
@@ -41,27 +41,6 @@ func TestMutatePodWithRemoveDefaultAnnotation(t *testing.T) {
 	}
 }
 
-func TestValidatePodWithRemoveDefaultAnnotation(t *testing.T) {
-	pod := corev1.Pod{}
-	var patches []string
-	var validationErrors []string
-
-	mutationAllowed := false
-
-	pod.Spec.ServiceAccountName = "default"
-	pod.Spec.Volumes = append([]corev1.Volume{}, corev1.Volume{Name: "default-token-abcd", VolumeSource: corev1.VolumeSource{}})
-	mounts := append([]corev1.VolumeMount{}, corev1.VolumeMount{Name: "default-token-abcd"})
-	pod.Spec.Containers = append([]corev1.Container{}, corev1.Container{Name: "first-container", VolumeMounts: mounts})
-
-	patches, validationErrors = admitServiceAccountToken(pod, "remove-default", mutationAllowed, patches, validationErrors)
-	if len(patches) != 0 {
-		t.Errorf("expected 0 patches but got: %+v", patches)
-	}
-	if len(validationErrors) != 1 {
-		t.Errorf("expected 1 validationErrors but got: %+v", validationErrors)
-	}
-}
-
 func TestMutatePodWithRemoveDefaultAnnotationNonDefaultServiceAccount(t *testing.T) {
 	pod := corev1.Pod{}
 	var patches []string


### PR DESCRIPTION
<!-- Thanks for sending a PR -->

### Description
The AdmitPod function is executed twice, once for the mutating
webhook and the second time for the validating webhook. This
will always cause a validation error and the pod creation gets
blocked.

### Checklist
Before submitting this PR, please make sure:
- [x] your code builds clean with `make test`
- [x] you have added unit tests
- [x] you have documented new or changed features
<!-- Please delete options that are not relevant -->
