### PR TITLE
Distinguish between mutating and validating service token pod webhook

### DIFF
--- a/pkg/admission/karydia/karydia.go
+++ b/pkg/admission/karydia/karydia.go
@@ -106,24 +106,27 @@ func admitServiceAccountToken(pod corev1.Pod, annotation string, mutationAllowed
 		}
 	} else if annotation == "remove-default" {
 		// Mutating webhook
+		if mutationAllowed {
 
-		if automountServiceAccountTokenUndefined(&pod) && pod.Spec.ServiceAccountName == "default" {
-			patches = append(patches, fmt.Sprintf(`{"op": "add", "path": "/spec/automountServiceAccountToken", "value": %s}`, "false"))
-			patches = append(patches, fmt.Sprintf(`{"op": "remove", "path": "/spec/serviceAccountName"}`))
-			for i, v := range pod.Spec.Volumes {
-				if strings.HasPrefix(v.Name, "default-token-") {
-					patches = append(patches, fmt.Sprintf(`{"op": "remove", "path": "/spec/volumes/%d"}`, i))
-				}
-			}
-			for i, c := range pod.Spec.Containers {
-				for j, v := range c.VolumeMounts {
+			if automountServiceAccountTokenUndefined(&pod) && pod.Spec.ServiceAccountName == "default" {
+				patches = append(patches, fmt.Sprintf(`{"op": "add", "path": "/spec/automountServiceAccountToken", "value": %s}`, "false"))
+				patches = append(patches, fmt.Sprintf(`{"op": "remove", "path": "/spec/serviceAccountName"}`))
+				for i, v := range pod.Spec.Volumes {
 					if strings.HasPrefix(v.Name, "default-token-") {
-						patches = append(patches, fmt.Sprintf(`{"op": "remove", "path": "/spec/containers/%d/volumeMounts/%d"}`, i, j))
+						patches = append(patches, fmt.Sprintf(`{"op": "remove", "path": "/spec/volumes/%d"}`, i))
+					}
+				}
+				for i, c := range pod.Spec.Containers {
+					for j, v := range c.VolumeMounts {
+						if strings.HasPrefix(v.Name, "default-token-") {
+							patches = append(patches, fmt.Sprintf(`{"op": "remove", "path": "/spec/containers/%d/volumeMounts/%d"}`, i, j))
+						}
 					}
 				}
 			}
+		} else if automountServiceAccountTokenUndefined(&pod) {
+			validationErrors = append(validationErrors, "option 'remove-default' for  karydia.gardener.cloud/automountServiceAccountToken is only available for mutating webhooks")
 		}
-
 	}
 	return patches, validationErrors
 }

--- a/pkg/admission/karydia/service_token_test.go
+++ b/pkg/admission/karydia/service_token_test.go
@@ -41,6 +41,27 @@ func TestMutatePodWithRemoveDefaultAnnotation(t *testing.T) {
 	}
 }
 
+func TestValidatePodWithRemoveDefaultAnnotation(t *testing.T) {
+	pod := corev1.Pod{}
+	var patches []string
+	var validationErrors []string
+
+	mutationAllowed := false
+
+	pod.Spec.ServiceAccountName = "default"
+	pod.Spec.Volumes = append([]corev1.Volume{}, corev1.Volume{Name: "default-token-abcd", VolumeSource: corev1.VolumeSource{}})
+	mounts := append([]corev1.VolumeMount{}, corev1.VolumeMount{Name: "default-token-abcd"})
+	pod.Spec.Containers = append([]corev1.Container{}, corev1.Container{Name: "first-container", VolumeMounts: mounts})
+
+	patches, validationErrors = admitServiceAccountToken(pod, "remove-default", mutationAllowed, patches, validationErrors)
+	if len(patches) != 0 {
+		t.Errorf("expected 0 patches but got: %+v", patches)
+	}
+	if len(validationErrors) != 1 {
+		t.Errorf("expected 1 validationErrors but got: %+v", validationErrors)
+	}
+}
+
 func TestMutatePodWithRemoveDefaultAnnotationNonDefaultServiceAccount(t *testing.T) {
 	pod := corev1.Pod{}
 	var patches []string


### PR DESCRIPTION


<!-- Thanks for sending a PR -->

### Description
Option karydia.gardener.cloud/automountServiceAccountToken=remove-default
is only applicable for the mutating webhook. If the mutating hook
is not registered at the api server, but the option remove-default
is set, karydia will return a meaningful error message and will deny
the deployment. If karydia is configured as mutating and validating
webhook, karydia acts accordingly and patches the object.


### Checklist
Before submitting this PR, please make sure:
- [x] your code builds clean with `make test`
- [x] you have added unit tests
<!-- Please delete options that are not relevant -->
