### PR TITLE
Fixed internal error when pod has no annotation

### DIFF
--- a/pkg/admission/karydiasecuritypolicy/pod_seccomp_test.go
+++ b/pkg/admission/karydiasecuritypolicy/pod_seccomp_test.go
@@ -33,6 +33,7 @@ func TestValidatePodSeccomp(t *testing.T) {
 		t.Errorf("expected no patches but got: %+v", patches)
 	}
 
+	// Pod with policy, but without annotation => should create annotation object
 	policy := &v1alpha1.KarydiaSecurityPolicy{
 		Spec: v1alpha1.KarydiaSecurityPolicySpec{
 			Pod: v1alpha1.Pod{
@@ -49,6 +50,20 @@ func TestValidatePodSeccomp(t *testing.T) {
 		t.Errorf("expected 1 patch but got: %+v", patches)
 	}
 
+	// Pod with policy and annotation => should add seccomp annotation
+        pod.ObjectMeta.Annotations = map[string]string{
+                "test": "value",
+        }
+
+        patches, validationErrors = validatePod(policy, pod)
+        if len(validationErrors) != 0 {
+                t.Errorf("expected 0 validation errors but got: %+v", validationErrors)
+        }
+        if len(patches) != 1 {
+                t.Errorf("expected 1 patch but got: %+v", patches)
+        }
+
+	// Pod with policy and seccomp annotation
 	pod.ObjectMeta.Annotations = map[string]string{
 		"seccomp.security.alpha.kubernetes.io/pod": "my-seccomp-profile",
 	}


### PR DESCRIPTION
### Description
If the pod doesn't have any annotations, karydia's attempt to patch the resource fails with
```
Error from server (InternalError): Internal error occurred: Internal error occurred: jsonpatch add operation does not apply: doc is missing path: "/metadata/annotations/seccomp.security.alpha.kubernetes.io~1pod"
```
This was due to [pkg/admission/karydiasecuritypolicy/pod.go (master)](https://github.com/karydia/karydia/blob/master/pkg/admission/karydiasecuritypolicy/pod.go#L118) and is fixed in [pkg/admission/karydiasecuritypolicy/pod.go](https://github.com/karydia/karydia/blob/securitypolicy-no-annotation/pkg/admission/karydiasecuritypolicy/pod.go#L118-L126).

This PR fixes #83.

### Checklist
Before submitting this PR, please make sure:
- [x] you have added unit tests
- [x] your code builds clean with `make`
- [x] your code lets succeed unit tests with `make test`
- [x] your code lets succeed integration tests