### PR TITLE
Change default behavior of ServiceAcounnts automount to false

### DIFF
--- a/contrib/gardener/scripts/configure-karydia-webhook-cp
+++ b/contrib/gardener/scripts/configure-karydia-webhook-cp
@@ -1,12 +1,14 @@
 #!/bin/bash
 #
-# Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+# Copyright (C) 2019 SAP SE or an SAP affiliate company. All rights reserved.
+# This file is licensed under the Apache Software License, v. 2 except as
+# noted otherwise in the LICENSE file.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      http:#www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/contrib/gardener/scripts/configure-karydia-webhook-cp
+++ b/contrib/gardener/scripts/configure-karydia-webhook-cp
@@ -46,6 +46,7 @@ webhooks:
         - namespaces
         - pods
         - pods/status
+        - serviceaccounts
         - endpoints
         - persistentvolumes
         - validatingwebhookconfigurations
@@ -77,6 +78,7 @@ webhooks:
         - namespaces
         - pods
         - pods/status
+        - serviceaccounts
         - endpoints
         - persistentvolumes
         - validatingwebhookconfigurations

--- a/contrib/gardener/scripts/configure-karydia-webhook-cp
+++ b/contrib/gardener/scripts/configure-karydia-webhook-cp
@@ -8,7 +8,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http:#www.apache.org/licenses/LICENSE-2.0
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/docs/features.md
+++ b/docs/features.md
@@ -33,19 +33,18 @@ additional code in Golang.
 ## Karydia admission
 
 Karydia Admission (`--enable-karydia-admission`) offers features with the goal
-of hardening a cluster setup.
+of a secure-by-default cluster setup.
 
 The features currently supported are:
-1. Prevent service account token automounts
-    - `forbidden` prevents pods with any service account token to be deployed
-    - `non-default` prevents pods with the default service account token to be deployed
-    - `remove-default` deploys pods, but removes default service account token when `automountServiceAccountToken` is not explicitly set to `true`.
+1. Secure-by-default mouting of service account tokens
+    - `change-default` sets `automountServiceAccountToken` of default ServiceAccounts to `false` when undefined
+    - `change-all` sets `automountServiceAccountToken` of all ServiceAccounts to `false` when undefined
 2. Enforcing a seccomp policy
 
 It is configured with the following namespace annotations:
 
 | Name | Type | Possible values |
 |---|---|---|
-|karydia.gardener.cloud/automountServiceAccountToken|string|`forbidden` \| `non-default` \| `remove-default`|
+|karydia.gardener.cloud/automountServiceAccountToken|string|`change-default` \| `change-all` 
 |karydia.gardener.cloud/seccompProfile|string|Name of a valid profile, e.g. `runtime/default` or `localhost/my-profile`|
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -36,7 +36,7 @@ Karydia Admission (`--enable-karydia-admission`) offers features with the goal
 of a secure-by-default cluster setup.
 
 The features currently supported are:
-1. Secure-by-default mouting of service account tokens
+1. Secure-by-default mounting of service account tokens
     - `change-default` sets `automountServiceAccountToken` of default ServiceAccounts to `false` when undefined
     - `change-all` sets `automountServiceAccountToken` of all ServiceAccounts to `false` when undefined
 2. Enforcing a seccomp policy
@@ -50,7 +50,7 @@ It is configured with the following namespace annotations:
 
 ### karydia.gardener.cloud/automountServiceAccountToken
 
-The feature defaults a service accounts `automountServiceAccountToken` to false in cases 5, 6 and 7. With setting `change-default` this is enforced for default service accounts, with setting `change-all` this is enforced for all service accounts (apart the ones in the `kube-system` namespace). The actual behavior of auto-mounting only changes in case 5, when `automountServiceAccountToken` is also undefined in the Pod definition. 
+The feature defaults a service account's `automountServiceAccountToken` to false in cases 5, 6 and 7 of the following table. With setting `change-default` this is enforced for default service accounts, with setting `change-all` this is enforced for all service accounts (apart the ones in the `kube-system` namespace). The actual behavior of auto-mounting only changes in case 5, when `automountServiceAccountToken` is also undefined in the Pod definition. 
 
 | # | service account | pod | k8s behavior | karydia behavior |
 |---|-----------------|-----|--------------|-----------------|

--- a/docs/features.md
+++ b/docs/features.md
@@ -48,3 +48,18 @@ It is configured with the following namespace annotations:
 |karydia.gardener.cloud/automountServiceAccountToken|string|`change-default` \| `change-all` 
 |karydia.gardener.cloud/seccompProfile|string|Name of a valid profile, e.g. `runtime/default` or `localhost/my-profile`|
 
+### karydia.gardener.cloud/automountServiceAccountToken
+
+The feature defaults a service accounts `automountServiceAccountToken` to false in cases 5, 6 and 7. With setting `change-default` this is enforced for default service accounts, with setting `change-all` this is enforced for all service accounts (apart the ones in the `kube-system` namespace). The actual behavior of auto-mounting only changes in case 5, when `automountServiceAccountToken` is also undefined in the Pod definition. 
+
+| # | service account | pod | k8s behavior | karydia behavior |
+|---|-----------------|-----|--------------|-----------------|
+|1| true | true | true | true |
+|2| false | true | true | true |
+|3| true | false | false | false |
+|4| false | false | false | false |
+|5| **not defined** | not defined | true | **false** |
+|6| **not defined** | true | true | true |
+|7| **not defined** | false | false | false |
+|8| true | not defined | true | true |
+|9| false | not defined | false | false |

--- a/pkg/admission/karydia/karydia.go
+++ b/pkg/admission/karydia/karydia.go
@@ -215,6 +215,7 @@ func (k *KarydiaAdmission) getNamespaceFromAdmissionRequest(ar v1beta1.Admission
 	return namespace, nil
 }
 
+/* Utility functions to decode raw resources into objects */
 func decodePod(raw []byte) (*corev1.Pod, error) {
 	pod := &corev1.Pod{}
 	deserializer := scheme.Codecs.UniversalDeserializer()
@@ -234,11 +235,14 @@ func decodeServiceAccount(raw []byte) (*corev1.ServiceAccount, error) {
 }
 
 func shouldIgnoreEvent(ar v1beta1.AdmissionReview) bool {
-	// Right now we only care about 'CREATE' events. Needs to be
-	// updated depending on the kind of admission requests that
-	// `KarydiaAdmission` should handle in this package.
-	// https://github.com/kubernetes/api/blob/kubernetes-1.12.2/admission/v1beta1/types.go#L118-L127
-	if ar.Request.Operation != v1beta1.Create {
+	/* Right now we only care about 'CREATE' and 'UPDATE' events.
+	   Needs to be updated depending on the kind of admission requests that
+	   `KarydiaAdmission` should handle in this package.
+	   https://github.com/kubernetes/api/blob/kubernetes-1.12.2/admission/v1beta1/types.go#L118-L127 */
+	const Create v1beta1.Operation = "CREATE"
+	const Update v1beta1.Operation = "UPDATE"
+	operation := ar.Request.Operation
+	if operation != Create && operation != Update {
 		return true
 	}
 	return false

--- a/pkg/admission/karydia/pod_admission.go
+++ b/pkg/admission/karydia/pod_admission.go
@@ -1,0 +1,83 @@
+// Copyright (C) 2019 SAP SE or an SAP affiliate company. All rights reserved.
+// This file is licensed under the Apache Software License, v. 2 except as
+// noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package karydia
+
+import (
+	"fmt"
+
+	"k8s.io/api/admission/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/karydia/karydia/pkg/k8sutil"
+	"github.com/karydia/karydia/pkg/k8sutil/scheme"
+)
+
+func (k *KarydiaAdmission) mutatePod(pod *corev1.Pod, ns *corev1.Namespace) *v1beta1.AdmissionResponse {
+	var patches []string
+
+	seccompProfile, annotated := ns.ObjectMeta.Annotations["karydia.gardener.cloud/seccompProfile"]
+	if annotated {
+		patches = mutatePodSeccompProfile(*pod, seccompProfile, patches)
+	}
+	return k8sutil.MutatingAdmissionResponse(patches)
+}
+
+func (k *KarydiaAdmission) validatePod(pod *corev1.Pod, ns *corev1.Namespace) *v1beta1.AdmissionResponse {
+	var validationErrors []string
+
+	seccompProfile, annotated := ns.ObjectMeta.Annotations["karydia.gardener.cloud/seccompProfile"]
+	if annotated {
+		validationErrors = validatePodSeccompProfile(*pod, seccompProfile, validationErrors)
+	}
+
+	return k8sutil.ValidatingAdmissionResponse(validationErrors)
+}
+
+func validatePodSeccompProfile(pod corev1.Pod, nsAnnotation string, validationErrors []string) []string {
+	seccompPod, ok := pod.ObjectMeta.Annotations["seccomp.security.alpha.kubernetes.io/pod"]
+	if !ok || seccompPod != nsAnnotation {
+		validationErrorMsg := fmt.Sprintf("seccomp profile ('seccomp.security.alpha.kubernetes.io/pod') must be '%s'", nsAnnotation)
+		validationErrors = append(validationErrors, validationErrorMsg)
+	}
+	return validationErrors
+}
+
+func mutatePodSeccompProfile(pod corev1.Pod, nsAnnotation string, patches []string) []string {
+	_, ok := pod.ObjectMeta.Annotations["seccomp.security.alpha.kubernetes.io/pod"]
+	if !ok {
+		if len(pod.ObjectMeta.Annotations) == 0 {
+			// If no annotation object exists yet, we have
+			// to create it. Otherwise we will encounter
+			// the following error:
+			// 'jsonpatch add operation does not apply: doc is missing path: "/metadata/annotations..."'
+			patches = append(patches, fmt.Sprintf(`{"op": "add", "path": "/metadata/annotations", "value": {"%s": "%s"}}`, "seccomp.security.alpha.kubernetes.io/pod", nsAnnotation))
+		} else {
+			patches = append(patches, fmt.Sprintf(`{"op": "add", "path": "/metadata/annotations/%s", "value": "%s"}`, "seccomp.security.alpha.kubernetes.io~1pod", nsAnnotation))
+		}
+	}
+	return patches
+}
+
+/* Utility functions to decode raw resources into objects */
+func decodePod(raw []byte) (*corev1.Pod, error) {
+	pod := &corev1.Pod{}
+	deserializer := scheme.Codecs.UniversalDeserializer()
+	if _, _, err := deserializer.Decode(raw, nil, pod); err != nil {
+		return nil, err
+	}
+	return pod, nil
+}

--- a/pkg/admission/karydia/service_account_admission.go
+++ b/pkg/admission/karydia/service_account_admission.go
@@ -1,0 +1,89 @@
+// Copyright (C) 2019 SAP SE or an SAP affiliate company. All rights reserved.
+// This file is licensed under the Apache Software License, v. 2 except as
+// noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package karydia
+
+import (
+	"fmt"
+
+	"k8s.io/api/admission/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/karydia/karydia/pkg/k8sutil"
+	"github.com/karydia/karydia/pkg/k8sutil/scheme"
+)
+
+func (k *KarydiaAdmission) mutateServiceAccount(sAcc *corev1.ServiceAccount, ns *corev1.Namespace) *v1beta1.AdmissionResponse {
+	var patches []string
+
+	automountServiceAccountToken, annotated := ns.ObjectMeta.Annotations["karydia.gardener.cloud/automountServiceAccountToken"]
+	if annotated {
+		patches = mutateServiceAccountTokenMount(*sAcc, automountServiceAccountToken, patches)
+	}
+
+	return k8sutil.MutatingAdmissionResponse(patches)
+}
+
+func (k *KarydiaAdmission) validateServiceAccount(sAcc *corev1.ServiceAccount, ns *corev1.Namespace) *v1beta1.AdmissionResponse {
+	var validationErrors []string
+
+	automountServiceAccountToken, annotated := ns.ObjectMeta.Annotations["karydia.gardener.cloud/automountServiceAccountToken"]
+	if annotated {
+		validationErrors = validateServiceAccountTokenMount(*sAcc, automountServiceAccountToken, validationErrors)
+	}
+
+	return k8sutil.ValidatingAdmissionResponse(validationErrors)
+}
+
+func validateServiceAccountTokenMount(sAcc corev1.ServiceAccount, nsAnnotation string, validationErrors []string) []string {
+	if nsAnnotation == "change-default" {
+		if automountServiceAccountTokenUndefined(&sAcc) && sAcc.Name == "default" {
+			validationErrors = append(validationErrors, "implicit automount of default service account token not allowed")
+		}
+	} else if nsAnnotation == "change-all" {
+		if automountServiceAccountTokenUndefined(&sAcc) {
+			validationErrors = append(validationErrors, "implicit automount of service account token not allowed")
+		}
+	}
+	return validationErrors
+}
+
+func mutateServiceAccountTokenMount(sAcc corev1.ServiceAccount, nsAnnotation string, patches []string) []string {
+	if nsAnnotation == "change-default" {
+		if automountServiceAccountTokenUndefined(&sAcc) && sAcc.Name == "default" {
+			patches = append(patches, fmt.Sprintf(`{"op": "add", "path": "/automountServiceAccountToken", "value": %s}`, "false"))
+		}
+	} else if nsAnnotation == "change-all" {
+		if automountServiceAccountTokenUndefined(&sAcc) {
+			patches = append(patches, fmt.Sprintf(`{"op": "add", "path": "/automountServiceAccountToken", "value": %s}`, "false"))
+		}
+	}
+	return patches
+}
+
+func automountServiceAccountTokenUndefined(sAcc *corev1.ServiceAccount) bool {
+	return sAcc.AutomountServiceAccountToken == nil
+}
+
+/* Utility functions to decode raw resources into objects */
+func decodeServiceAccount(raw []byte) (*corev1.ServiceAccount, error) {
+	sAcc := &corev1.ServiceAccount{}
+	deserializer := scheme.Codecs.UniversalDeserializer()
+	if _, _, err := deserializer.Decode(raw, nil, sAcc); err != nil {
+		return nil, err
+	}
+	return sAcc, nil
+}

--- a/pkg/admission/karydia/service_token_test.go
+++ b/pkg/admission/karydia/service_token_test.go
@@ -27,161 +27,297 @@ import (
 )
 
 /* Mutating and Validating Webhook
- * Removes token mounts of the default service account when automountServiceToken is undefined.
- * kubectl annotate ns default karydia.gardener.cloud/automountServiceAccountToken=remove-default
+ * Changes the default of automountServiceToken for the default service accounts
+ * from true to false when undefined.
+ * kubectl annotate ns default karydia.gardener.cloud/automountServiceAccountToken=change-default
  */
-func TestPodRemoveDefaultAnnotationDefaultServiceAccount(t *testing.T) {
-	pod := corev1.Pod{}
+func TestServiceAccountChangeDefaultAnnotationDefaultServiceAccountMountUndefined(t *testing.T) {
 	var patches []string
 	var validationErrors []string
 
-	pod.Spec.ServiceAccountName = "default"
-	pod.Spec.Volumes = append([]corev1.Volume{}, corev1.Volume{Name: "default-token-abcd", VolumeSource: corev1.VolumeSource{}})
-	mounts := append([]corev1.VolumeMount{}, corev1.VolumeMount{Name: "default-token-abcd"})
-	pod.Spec.Containers = append([]corev1.Container{}, corev1.Container{Name: "first-container", VolumeMounts: mounts})
+	sAcc := corev1.ServiceAccount{}
+	sAcc.Name = "default"
 
-	patches = mutatePodServiceAccountToken(pod, "remove-default", patches)
-	if len(patches) != 3 {
-		t.Errorf("expected 3 patches but got: %+v", patches)
+	patches = mutateServiceAccountTokenMount(sAcc, "change-default", patches)
+	if len(patches) != 1 {
+		t.Errorf("expected 1 patches but got: %+v", patches)
 	}
-	mutatedPod, err := patchPod(pod, patches)
+	mutatedServiceAccount, err := patchServiceAccount(sAcc, patches)
 	if err != nil {
 		t.Errorf("failed to apply patches: %+v", err)
 	}
 	// Zero validation errors expected for mutated pod
-	validationErrors = validatePodServiceAccountToken(mutatedPod, "remove-default", validationErrors)
+	validationErrors = validateServiceAccountTokenMount(mutatedServiceAccount, "change-default", validationErrors)
 	if len(validationErrors) != 0 {
 		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
 	}
 	validationErrors = []string{}
 	// One validation error expected for initial pod
-	validationErrors = validatePodServiceAccountToken(pod, "remove-default", validationErrors)
+	validationErrors = validateServiceAccountTokenMount(sAcc, "change-default", validationErrors)
 	if len(validationErrors) != 1 {
 		t.Errorf("expected 1 validationErrors but got: %+v", validationErrors)
 	}
 }
 
-func TestPodRemoveDefaultAnnotationSpecificServiceAccount(t *testing.T) {
-	pod := corev1.Pod{}
+func TestServiceAccountChangeDefaultAnnotationDefaultServiceAccountMountFalse(t *testing.T) {
 	var patches []string
 	var validationErrors []string
+	var automount = false
 
-	pod.Spec.ServiceAccountName = "test"
-	pod.Spec.Volumes = append([]corev1.Volume{}, corev1.Volume{Name: "test-token-abcd", VolumeSource: corev1.VolumeSource{}})
-	mounts := append([]corev1.VolumeMount{}, corev1.VolumeMount{Name: "test-token-abcd"})
-	pod.Spec.Containers = append([]corev1.Container{}, corev1.Container{Name: "first-container", VolumeMounts: mounts})
+	sAcc := corev1.ServiceAccount{}
+	sAcc.Name = "default"
+	sAcc.AutomountServiceAccountToken = &(automount)
 
-	patches = mutatePodServiceAccountToken(pod, "remove-default", patches)
+	patches = mutateServiceAccountTokenMount(sAcc, "change-default", patches)
 	if len(patches) != 0 {
 		t.Errorf("expected 0 patches but got: %+v", patches)
 	}
-	mutatedPod, err := patchPod(pod, patches)
+	mutatedServiceAccount, err := patchServiceAccount(sAcc, patches)
 	if err != nil {
 		t.Errorf("failed to apply patches: %+v", err)
 	}
 	// Zero validation errors expected for mutated pod
-	validationErrors = validatePodServiceAccountToken(mutatedPod, "remove-default", validationErrors)
+	validationErrors = validateServiceAccountTokenMount(mutatedServiceAccount, "change-default", validationErrors)
 	if len(validationErrors) != 0 {
 		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
 	}
 	validationErrors = []string{}
-	// Zero validation errors expected for initial pod
-	validationErrors = validatePodServiceAccountToken(pod, "remove-default", validationErrors)
+	// Zero validation errors expected for mutated pod
+	validationErrors = validateServiceAccountTokenMount(sAcc, "change-default", validationErrors)
 	if len(validationErrors) != 0 {
 		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
 	}
 }
 
-func TestPodRemoveDefaultAnnotationDefaultSerivceAccountMultipleVolumes(t *testing.T) {
-	pod := corev1.Pod{}
+func TestServiceAccountChangeDefaultAnnotationDefaultServiceAccountMountTrue(t *testing.T) {
 	var patches []string
 	var validationErrors []string
+	var automount = true
 
-	pod.Spec.ServiceAccountName = "default"
-	pod.Spec.Volumes = append([]corev1.Volume{}, corev1.Volume{Name: "default-token-abcd", VolumeSource: corev1.VolumeSource{}})
-	pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{Name: "test-token-abcd", VolumeSource: corev1.VolumeSource{}})
-	mounts := append([]corev1.VolumeMount{}, corev1.VolumeMount{Name: "default-token-abcd"})
-	mounts = append(mounts, corev1.VolumeMount{Name: "test-token-abcd"})
-	pod.Spec.Containers = append([]corev1.Container{}, corev1.Container{Name: "first-container", VolumeMounts: mounts})
+	sAcc := corev1.ServiceAccount{}
+	sAcc.Name = "default"
+	sAcc.AutomountServiceAccountToken = &(automount)
 
-	patches = mutatePodServiceAccountToken(pod, "remove-default", patches)
-	if len(patches) != 3 {
-		t.Errorf("expected 3 patches but got: %+v", patches)
+	patches = mutateServiceAccountTokenMount(sAcc, "change-default", patches)
+	if len(patches) != 0 {
+		t.Errorf("expected 0 patches but got: %+v", patches)
 	}
-	mutatedPod, err := patchPod(pod, patches)
+	mutatedServiceAccount, err := patchServiceAccount(sAcc, patches)
 	if err != nil {
 		t.Errorf("failed to apply patches: %+v", err)
 	}
 	// Zero validation errors expected for mutated pod
-	validationErrors = validatePodServiceAccountToken(mutatedPod, "remove-default", validationErrors)
+	validationErrors = validateServiceAccountTokenMount(mutatedServiceAccount, "change-default", validationErrors)
+	if len(validationErrors) != 0 {
+		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
+	}
+	validationErrors = []string{}
+	// Zero validation errors expected for mutated pod
+	validationErrors = validateServiceAccountTokenMount(sAcc, "change-default", validationErrors)
+	if len(validationErrors) != 0 {
+		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
+	}
+}
+
+func TestServiceAccountChangeDefaultAnnotationSpecificServiceAccountMountUndefined(t *testing.T) {
+	var patches []string
+	var validationErrors []string
+
+	sAcc := corev1.ServiceAccount{}
+	sAcc.Name = "specific"
+
+	patches = mutateServiceAccountTokenMount(sAcc, "change-default", patches)
+	if len(patches) != 0 {
+		t.Errorf("expected 0 patches but got: %+v", patches)
+	}
+	mutatedServiceAccount, err := patchServiceAccount(sAcc, patches)
+	if err != nil {
+		t.Errorf("failed to apply patches: %+v", err)
+	}
+	// Zero validation errors expected for mutated pod
+	validationErrors = validateServiceAccountTokenMount(mutatedServiceAccount, "change-default", validationErrors)
+	if len(validationErrors) != 0 {
+		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
+	}
+	validationErrors = []string{}
+	// Zero validation errors expected for mutated pod
+	validationErrors = validateServiceAccountTokenMount(sAcc, "change-default", validationErrors)
+	if len(validationErrors) != 0 {
+		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
+	}
+}
+func TestServiceAccountRandomAnnotationDefaultServiceAccountMountUndefined(t *testing.T) {
+	var patches []string
+	var validationErrors []string
+
+	sAcc := corev1.ServiceAccount{}
+	sAcc.Name = "default"
+
+	patches = mutateServiceAccountTokenMount(sAcc, "random", patches)
+	if len(patches) != 0 {
+		t.Errorf("expected 0 patches but got: %+v", patches)
+	}
+	mutatedServiceAccount, err := patchServiceAccount(sAcc, patches)
+	if err != nil {
+		t.Errorf("failed to apply patches: %+v", err)
+	}
+	// Zero validation errors expected for mutated pod
+	validationErrors = validateServiceAccountTokenMount(mutatedServiceAccount, "random", validationErrors)
+	if len(validationErrors) != 0 {
+		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
+	}
+	validationErrors = []string{}
+	// Zero validation errors expected for mutated pod
+	validationErrors = validateServiceAccountTokenMount(sAcc, "random", validationErrors)
+	if len(validationErrors) != 0 {
+		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
+	}
+}
+
+/* Mutating and Validating Webhook
+ * Changes the default of automountServiceToken for all service accounts
+ * from true to false when undefined.
+ * kubectl annotate ns default karydia.gardener.cloud/automountServiceAccountToken=change-all
+ */
+func TestServiceAccountChangeAllAnnotationDefaultServiceAccountMountUndefined(t *testing.T) {
+	var patches []string
+	var validationErrors []string
+
+	sAcc := corev1.ServiceAccount{}
+	sAcc.Name = "default"
+
+	patches = mutateServiceAccountTokenMount(sAcc, "change-all", patches)
+	if len(patches) != 1 {
+		t.Errorf("expected 1 patches but got: %+v", patches)
+	}
+	mutatedServiceAccount, err := patchServiceAccount(sAcc, patches)
+	if err != nil {
+		t.Errorf("failed to apply patches: %+v", err)
+	}
+	// Zero validation errors expected for mutated pod
+	validationErrors = validateServiceAccountTokenMount(mutatedServiceAccount, "change-all", validationErrors)
 	if len(validationErrors) != 0 {
 		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
 	}
 	validationErrors = []string{}
 	// One validation error expected for initial pod
-	validationErrors = validatePodServiceAccountToken(pod, "remove-default", validationErrors)
+	validationErrors = validateServiceAccountTokenMount(sAcc, "change-all", validationErrors)
 	if len(validationErrors) != 1 {
 		t.Errorf("expected 1 validationErrors but got: %+v", validationErrors)
 	}
 }
 
-/* Validating webhook that disallows token mounts of any service account
- * kubectl annotate ns default karydia.gardener.cloud/automountServiceAccountToken=forbidden
- */
-func TestPodForbiddentAnnotationDefaultServiceAccount(t *testing.T) {
-	pod := corev1.Pod{}
+func TestServiceAccountChangeAllAnnotationSpecificServiceAccountMountUndefined(t *testing.T) {
 	var patches []string
 	var validationErrors []string
 
-	pod.Spec.ServiceAccountName = "default"
+	sAcc := corev1.ServiceAccount{}
+	sAcc.Name = "specific"
 
-	patches = mutatePodServiceAccountToken(pod, "forbidden", patches)
-	if len(patches) != 0 {
-		t.Errorf("expected 0 patches but got: %+v", patches)
+	patches = mutateServiceAccountTokenMount(sAcc, "change-all", patches)
+	if len(patches) != 1 {
+		t.Errorf("expected 1 patches but got: %+v", patches)
 	}
-	validationErrors = validatePodServiceAccountToken(pod, "forbidden", validationErrors)
+	mutatedServiceAccount, err := patchServiceAccount(sAcc, patches)
+	if err != nil {
+		t.Errorf("failed to apply patches: %+v", err)
+	}
+	// Zero validation errors expected for mutated pod
+	validationErrors = validateServiceAccountTokenMount(mutatedServiceAccount, "change-all", validationErrors)
+	if len(validationErrors) != 0 {
+		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
+	}
+	validationErrors = []string{}
+	// One validation error expected for initial pod
+	validationErrors = validateServiceAccountTokenMount(sAcc, "change-all", validationErrors)
 	if len(validationErrors) != 1 {
 		t.Errorf("expected 1 validationErrors but got: %+v", validationErrors)
 	}
 }
 
-/* Validating webhook that disallows token mounts of the default service account
- * kubectl annotate ns default karydia.gardener.cloud/automountServiceAccountToken=non-default
- */
-func TestPodNonDefaultAnnotationDefaultServiceAccount(t *testing.T) {
-	pod := corev1.Pod{}
+func TestServiceAccountChangeAllAnnotationSpecificServiceAccountMountFalse(t *testing.T) {
 	var patches []string
 	var validationErrors []string
+	var automount = false
 
-	pod.Spec.ServiceAccountName = "default"
-	pod.Spec.Volumes = append([]corev1.Volume{}, corev1.Volume{Name: "default-token-abcd", VolumeSource: corev1.VolumeSource{}})
-	mounts := append([]corev1.VolumeMount{}, corev1.VolumeMount{Name: "default-token-abcd"})
-	pod.Spec.Containers = append([]corev1.Container{}, corev1.Container{Name: "first-container", VolumeMounts: mounts})
+	sAcc := corev1.ServiceAccount{}
+	sAcc.Name = "specific"
+	sAcc.AutomountServiceAccountToken = &(automount)
 
-	patches = mutatePodServiceAccountToken(pod, "non-default", patches)
+	patches = mutateServiceAccountTokenMount(sAcc, "change-all", patches)
 	if len(patches) != 0 {
 		t.Errorf("expected 0 patches but got: %+v", patches)
 	}
-	validationErrors = validatePodServiceAccountToken(pod, "non-default", validationErrors)
-	if len(validationErrors) != 1 {
-		t.Errorf("expected 1 validationErrors but got: %+v", validationErrors)
+	mutatedServiceAccount, err := patchServiceAccount(sAcc, patches)
+	if err != nil {
+		t.Errorf("failed to apply patches: %+v", err)
+	}
+	// Zero validation errors expected for mutated pod
+	validationErrors = validateServiceAccountTokenMount(mutatedServiceAccount, "change-all", validationErrors)
+	if len(validationErrors) != 0 {
+		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
+	}
+	validationErrors = []string{}
+	// Zero validation errors expected for mutated pod
+	validationErrors = validateServiceAccountTokenMount(sAcc, "change-all", validationErrors)
+	if len(validationErrors) != 0 {
+		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
 	}
 }
 
-func TestPodNonDefaultAnnotationSpecificServiceAccount(t *testing.T) {
-	pod := corev1.Pod{}
+func TestServiceAccountChangeAllAnnotationspecificServiceAccountMountTrue(t *testing.T) {
 	var patches []string
 	var validationErrors []string
+	var automount = true
 
-	pod.Spec.ServiceAccountName = "test"
-	pod.Spec.Volumes = append([]corev1.Volume{}, corev1.Volume{Name: "test-token-abcd", VolumeSource: corev1.VolumeSource{}})
-	mounts := append([]corev1.VolumeMount{}, corev1.VolumeMount{Name: "test-token-abcd"})
-	pod.Spec.Containers = append([]corev1.Container{}, corev1.Container{Name: "first-container", VolumeMounts: mounts})
-	patches = mutatePodServiceAccountToken(pod, "non-default", patches)
+	sAcc := corev1.ServiceAccount{}
+	sAcc.Name = "specific"
+	sAcc.AutomountServiceAccountToken = &(automount)
+
+	patches = mutateServiceAccountTokenMount(sAcc, "change-all", patches)
 	if len(patches) != 0 {
 		t.Errorf("expected 0 patches but got: %+v", patches)
 	}
-	validationErrors = validatePodServiceAccountToken(pod, "non-default", validationErrors)
+	mutatedServiceAccount, err := patchServiceAccount(sAcc, patches)
+	if err != nil {
+		t.Errorf("failed to apply patches: %+v", err)
+	}
+	// Zero validation errors expected for mutated pod
+	validationErrors = validateServiceAccountTokenMount(mutatedServiceAccount, "change-all", validationErrors)
+	if len(validationErrors) != 0 {
+		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
+	}
+	validationErrors = []string{}
+	// Zero validation errors expected for mutated pod
+	validationErrors = validateServiceAccountTokenMount(sAcc, "change-all", validationErrors)
+	if len(validationErrors) != 0 {
+		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
+	}
+}
+
+func TestServiceAccountRandomAnnotationSpecificServiceAccountMountUndefined(t *testing.T) {
+	var patches []string
+	var validationErrors []string
+
+	sAcc := corev1.ServiceAccount{}
+	sAcc.Name = "specific"
+
+	patches = mutateServiceAccountTokenMount(sAcc, "random", patches)
+	if len(patches) != 0 {
+		t.Errorf("expected 0 patches but got: %+v", patches)
+	}
+	mutatedServiceAccount, err := patchServiceAccount(sAcc, patches)
+	if err != nil {
+		t.Errorf("failed to apply patches: %+v", err)
+	}
+	// Zero validation errors expected for mutated pod
+	validationErrors = validateServiceAccountTokenMount(mutatedServiceAccount, "random", validationErrors)
+	if len(validationErrors) != 0 {
+		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
+	}
+	validationErrors = []string{}
+	// Zero validation errors expected for mutated pod
+	validationErrors = validateServiceAccountTokenMount(sAcc, "random", validationErrors)
 	if len(validationErrors) != 0 {
 		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
 	}
@@ -211,4 +347,29 @@ func patchPod(pod corev1.Pod, patches []string) (corev1.Pod, error) {
 	json.Unmarshal(podPatchedJSON, &podPatched)
 
 	return podPatched, nil
+}
+
+func patchServiceAccount(sAcc corev1.ServiceAccount, patches []string) (corev1.ServiceAccount, error) {
+	var podJSON []byte
+	podJSON, err := json.Marshal(&sAcc)
+	if err != nil {
+		return sAcc, err
+	}
+
+	patchesStr := strings.Join(patches, ",")
+	patchesByteStr := []byte(fmt.Sprintf("[%s]", patchesStr))
+
+	patchObj, err := jsonpatch.DecodePatch(patchesByteStr)
+	if err != nil {
+		return sAcc, err
+	}
+	sAccPatchedJSON, err := patchObj.Apply(podJSON)
+	if err != nil {
+		return sAcc, err
+	}
+
+	var sAccPatched corev1.ServiceAccount
+	json.Unmarshal(sAccPatchedJSON, &sAccPatched)
+
+	return sAccPatched, nil
 }

--- a/scripts/configure-karydia-webhook
+++ b/scripts/configure-karydia-webhook
@@ -1,12 +1,14 @@
 #!/bin/bash
 #
-# Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+# Copyright (C) 2019 SAP SE or an SAP affiliate company. All rights reserved.
+# This file is licensed under the Apache Software License, v. 2 except as
+# noted otherwise in the LICENSE file.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      http:#www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/scripts/configure-karydia-webhook
+++ b/scripts/configure-karydia-webhook
@@ -49,6 +49,7 @@ webhooks:
         - namespaces
         - pods
         - pods/status
+        - serviceaccounts
         - endpoints
         - persistentvolumes
         - validatingwebhookconfigurations
@@ -83,6 +84,7 @@ webhooks:
         - namespaces
         - pods
         - pods/status
+        - serviceaccounts
         - endpoints
         - persistentvolumes
         - validatingwebhookconfigurations

--- a/scripts/configure-karydia-webhook
+++ b/scripts/configure-karydia-webhook
@@ -8,7 +8,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http:#www.apache.org/licenses/LICENSE-2.0
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/tests/e2e/framework/framework.go
+++ b/tests/e2e/framework/framework.go
@@ -107,6 +107,22 @@ func (f *Framework) CreateTestNamespace() (*corev1.Namespace, error) {
 	return ns, nil
 }
 
+func (f *Framework) CreateTestNamespaceWithAnnotation(annotations map[string]string) (*corev1.Namespace, error) {
+	ns, err := f.KubeClientset.CoreV1().Namespaces().Create(&corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "karydia-e2e-test-",
+			Labels: map[string]string{
+				"app": "karydia-e2e-test",
+			},
+			Annotations: annotations,
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create namespace %q: %v", f.Namespace, err)
+	}
+	return ns, nil
+}
+
 func (f *Framework) SetupKarydia() error {
 	// Create service account
 	sa := &corev1.ServiceAccount{

--- a/tests/e2e/framework/framework.go
+++ b/tests/e2e/framework/framework.go
@@ -514,3 +514,13 @@ func (f *Framework) WaitPodRunning(namespace, name string, timeout time.Duration
 		return true, nil
 	})
 }
+
+func (f *Framework) WaitDefaultServiceAccountCreated(ns string, timeout time.Duration) error {
+	return wait.Poll(100*time.Millisecond, timeout, func() (bool, error) {
+		_, err := f.KubeClientset.CoreV1().ServiceAccounts(ns).Get("default", metav1.GetOptions{})
+		if err != nil {
+			return false, fmt.Errorf("failed to get pods: %v", err)
+		}
+		return true, nil
+	})
+}

--- a/tests/e2e/framework/framework.go
+++ b/tests/e2e/framework/framework.go
@@ -493,6 +493,11 @@ func (f *Framework) DeleteAll() error {
 			return fmt.Errorf("failed to delete namespace %q: %v", name, err)
 		}
 	}
+	/* Delete single pod in default namespace */
+	err = f.KubeClientset.CoreV1().Pods("default").Delete("karydia-e2e-test-pod", &metav1.DeleteOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to delete pod in default namespace")
+	}
 	return nil
 }
 

--- a/tests/e2e/framework/framework.go
+++ b/tests/e2e/framework/framework.go
@@ -1,4 +1,6 @@
-// Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+// Copyright (C) 2019 SAP SE or an SAP affiliate company. All rights reserved.
+// This file is licensed under the Apache Software License, v. 2 except as
+// noted otherwise in the LICENSE file.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/e2e/framework/framework.go
+++ b/tests/e2e/framework/framework.go
@@ -516,10 +516,10 @@ func (f *Framework) WaitPodRunning(namespace, name string, timeout time.Duration
 }
 
 func (f *Framework) WaitDefaultServiceAccountCreated(ns string, timeout time.Duration) error {
-	return wait.Poll(100*time.Millisecond, timeout, func() (bool, error) {
+	return wait.Poll(200*time.Millisecond, timeout, func() (bool, error) {
 		_, err := f.KubeClientset.CoreV1().ServiceAccounts(ns).Get("default", metav1.GetOptions{})
 		if err != nil {
-			return false, fmt.Errorf("failed to get pods: %v", err)
+			return false, nil
 		}
 		return true, nil
 	})

--- a/tests/e2e/karydia_admission_test.go
+++ b/tests/e2e/karydia_admission_test.go
@@ -201,7 +201,7 @@ func TestAutomountServiceAccountToken(t *testing.T) {
 /*
 Single test case for default ServiceAccount in the default Namespace
 
-This represents a special case, since the this service account
+This represents a special case, since this service account
 is already present when karydia is installed configuration via
 web-hook won't work.
 */

--- a/tests/e2e/karydia_admission_test.go
+++ b/tests/e2e/karydia_admission_test.go
@@ -15,7 +15,8 @@
 package e2e
 
 import (
-	"strings"
+	"fmt"
+	"strconv"
 	"testing"
 	"time"
 
@@ -23,158 +24,199 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestAutomountServiceAccountTokenForbidden(t *testing.T) {
-	namespace, err := f.CreateTestNamespace()
-	if err != nil {
-		t.Fatalf("failed to create test namespace: %v", err)
-	}
+var changeDefault = "change-default"
+var changeAll = "change-all"
+var vTrue = true
+var vFalse = false
 
-	namespace.ObjectMeta.Annotations = map[string]string{
-		"karydia.gardener.cloud/automountServiceAccountToken": "forbidden",
-	}
-
-	namespace, err = f.KubeClientset.CoreV1().Namespaces().Update(namespace)
-	if err != nil {
-		t.Fatalf("failed to annotate test namespace: %v", err)
-	}
-
-	ns := namespace.ObjectMeta.Name
-
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "karydia-e2e-test-pod",
-			Namespace: ns,
-		},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{
-				{
-					Name:  "nginx",
-					Image: "nginx",
-				},
-			},
-		},
-	}
-
-	_, err = f.KubeClientset.CoreV1().Pods(ns).Create(pod)
-	if err == nil {
-		t.Fatalf("expected pod creation to fail")
-	}
-
-	automountServiceAccountToken := false
-	pod.Spec.AutomountServiceAccountToken = &automountServiceAccountToken
-
-	pod, err = f.KubeClientset.CoreV1().Pods(ns).Create(pod)
-	if err != nil {
-		t.Fatalf("failed to create pod: %v", err)
-	}
-
-	timeout := 2 * time.Minute
-	if err := f.WaitPodRunning(pod.ObjectMeta.Namespace, pod.ObjectMeta.Name, timeout); err != nil {
-		t.Fatalf("pod never reached state running")
-	}
-
+type AutomountTokenTestCase struct {
+	serviceAccount               string
+	nsAnnotation                 *string
+	automountTokenServiceAccount *bool
+	automountTokenPod            *bool
+	mounted                      bool
 }
 
-func TestAutomountServiceAccountTokenNonDefault(t *testing.T) {
-	namespace, err := f.CreateTestNamespace()
-	if err != nil {
-		t.Fatalf("failed to create test namespace: %v", err)
+func TestAutomountServiceAccountToken(t *testing.T) {
+	testCases := []AutomountTokenTestCase{
+		{"default", nil, nil, nil, true},
+		{"default", nil, nil, &vTrue, true},
+		{"default", nil, nil, &vFalse, false},
+		{"default", nil, &vTrue, nil, true},
+		{"default", nil, &vTrue, &vTrue, true},
+		{"default", nil, &vTrue, &vFalse, false},
+		{"default", nil, &vFalse, nil, false},
+		{"default", nil, &vFalse, &vTrue, true},
+		{"default", nil, &vFalse, &vFalse, false},
+
+		{"default", &changeDefault, nil, nil, false},
+		{"default", &changeDefault, nil, &vTrue, true},
+		{"default", &changeDefault, nil, &vFalse, false},
+		{"default", &changeDefault, &vTrue, nil, true},
+		{"default", &changeDefault, &vTrue, &vTrue, true},
+		{"default", &changeDefault, &vTrue, &vFalse, false},
+		{"default", &changeDefault, &vFalse, nil, false},
+		{"default", &changeDefault, &vFalse, &vTrue, true},
+		{"default", &changeDefault, &vFalse, &vFalse, false},
+
+		{"default", &changeAll, nil, nil, false},
+		{"default", &changeAll, nil, &vTrue, true},
+		{"default", &changeAll, nil, &vFalse, false},
+		{"default", &changeAll, &vTrue, nil, true},
+		{"default", &changeAll, &vTrue, &vTrue, true},
+		{"default", &changeAll, &vTrue, &vFalse, false},
+		{"default", &changeAll, &vFalse, nil, false},
+		{"default", &changeAll, &vFalse, &vTrue, true},
+		{"default", &changeAll, &vFalse, &vFalse, false},
+
+		{"dedicated", nil, nil, nil, true},
+		{"dedicated", nil, nil, &vTrue, true},
+		{"dedicated", nil, nil, &vFalse, false},
+		{"dedicated", nil, &vTrue, nil, true},
+		{"dedicated", nil, &vTrue, &vTrue, true}, //
+		{"dedicated", nil, &vTrue, &vFalse, false},
+		{"dedicated", nil, &vFalse, nil, false},
+		{"dedicated", nil, &vFalse, &vTrue, true},
+		{"dedicated", nil, &vFalse, &vFalse, false},
+
+		{"dedicated", &changeDefault, nil, nil, true},
+		{"dedicated", &changeDefault, nil, &vTrue, true},
+		{"dedicated", &changeDefault, nil, &vFalse, false},
+		{"dedicated", &changeDefault, &vTrue, nil, true},
+		{"dedicated", &changeDefault, &vTrue, &vTrue, true},
+		{"dedicated", &changeDefault, &vTrue, &vFalse, false},
+		{"dedicated", &changeDefault, &vFalse, nil, false},
+		{"dedicated", &changeDefault, &vFalse, &vTrue, true},
+		{"dedicated", &changeDefault, &vFalse, &vFalse, false},
+
+		{"dedicated", &changeAll, nil, nil, false},
+		{"dedicated", &changeAll, nil, &vTrue, true},
+		{"dedicated", &changeAll, nil, &vFalse, false},
+		{"dedicated", &changeAll, &vTrue, nil, true},
+		{"dedicated", &changeAll, &vTrue, &vTrue, true},
+		{"dedicated", &changeAll, &vTrue, &vFalse, false},
+		{"dedicated", &changeAll, &vFalse, nil, false},
+		{"dedicated", &changeAll, &vFalse, &vTrue, true},
+		{"dedicated", &changeAll, &vFalse, &vFalse, false},
 	}
 
-	namespace.ObjectMeta.Annotations = map[string]string{
-		"karydia.gardener.cloud/automountServiceAccountToken": "non-default",
-	}
+	for _, tc := range testCases {
+		t.Run(stringifyTestCase(tc), func(t *testing.T) {
+			namespace, err := f.CreateTestNamespace()
+			if err != nil {
+				t.Fatalf("failed to create test namespace: %v", err)
+			}
+			if tc.nsAnnotation != nil {
+				namespace.ObjectMeta.Annotations = map[string]string{
+					"karydia.gardener.cloud/automountServiceAccountToken": *tc.nsAnnotation,
+				}
 
-	namespace, err = f.KubeClientset.CoreV1().Namespaces().Update(namespace)
-	if err != nil {
-		t.Fatalf("failed to annotate test namespace: %v", err)
-	}
+				namespace, err = f.KubeClientset.CoreV1().Namespaces().Update(namespace)
+				if err != nil {
+					t.Fatalf("failed to annotate test namespace: %v", err)
+				}
+			}
 
-	ns := namespace.ObjectMeta.Name
+			ns := namespace.ObjectMeta.Name
 
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "karydia-e2e-test-pod",
-			Namespace: ns,
-		},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{
-				{
-					Name:  "nginx",
-					Image: "nginx",
+			if tc.serviceAccount != "" && tc.serviceAccount != "default" {
+				sAcc, err := f.CreateServiceAccount(tc.serviceAccount, ns)
+				if err != nil {
+					t.Fatalf("failed to create service account: %v", err)
+				}
+				if tc.nsAnnotation != nil && *tc.nsAnnotation == "change-default" {
+					if sAcc.AutomountServiceAccountToken != nil {
+						t.Fatalf("expected service account automount to be undefined")
+					}
+				} else if tc.nsAnnotation != nil && *tc.nsAnnotation == "change-all" {
+					if sAcc.AutomountServiceAccountToken != nil && *sAcc.AutomountServiceAccountToken != false {
+						t.Fatalf("expected service account automount to be false")
+					}
+				}
+			} else {
+				timeout := 500 * time.Millisecond
+				if err := f.WaitDefaultServiceAccountCreated(ns, timeout); err != nil {
+					t.Fatalf("default service account not created")
+				}
+			}
+
+			if tc.automountTokenServiceAccount != nil {
+				sAcc, err := f.KubeClientset.CoreV1().ServiceAccounts(ns).Get(tc.serviceAccount, metav1.GetOptions{})
+				if err != nil {
+					t.Fatalf("failed to retrieve service account: %v", err)
+				}
+				sAcc.AutomountServiceAccountToken = tc.automountTokenServiceAccount
+				sAcc, err = f.KubeClientset.CoreV1().ServiceAccounts(ns).Update(sAcc)
+				if err != nil {
+					t.Fatalf("failed to update service account: %v", err)
+				}
+			}
+
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "karydia-e2e-test-pod",
+					Namespace: ns,
 				},
-			},
-		},
-	}
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "nginx",
+							Image: "nginx",
+						},
+					},
+				},
+			}
 
-	_, err = f.KubeClientset.CoreV1().Pods(ns).Create(pod)
-	if err == nil {
-		t.Fatalf("expected pod creation to fail")
-	}
+			pod.Spec.ServiceAccountName = tc.serviceAccount
+			if tc.automountTokenPod != nil {
+				pod.Spec.AutomountServiceAccountToken = tc.automountTokenPod
+			}
 
-	serviceAccount, err := f.CreateServiceAccount("non-default", namespace.GetName())
-	if err != nil {
-		t.Fatalf("failed to create service account: %v", err)
-	}
+			createdPod, err := f.KubeClientset.CoreV1().Pods(ns).Create(pod)
+			if err != nil {
+				t.Fatalf("failed to create pod: %v", err)
+			}
 
-	pod.Spec.ServiceAccountName = serviceAccount.GetName()
-	pod, err = f.KubeClientset.CoreV1().Pods(ns).Create(pod)
-	if err != nil {
-		t.Fatalf("failed to create pod: %v", err)
-	}
+			if createdPod.Spec.AutomountServiceAccountToken != nil && *createdPod.Spec.AutomountServiceAccountToken != tc.mounted {
+				t.Fatalf("expected automountServiceAccountToken to be %v but is %v", tc.mounted, *createdPod.Spec.AutomountServiceAccountToken)
+			}
 
-	timeout := 2 * time.Minute
-	if err := f.WaitPodRunning(pod.ObjectMeta.Namespace, pod.ObjectMeta.Name, timeout); err != nil {
-		t.Fatalf("pod never reached state running")
+			if (len(createdPod.Spec.Volumes) == 1) != tc.mounted {
+				t.Fatalf("expected is mounted to be %v but is %v", tc.mounted, len(createdPod.Spec.Volumes) == 1)
+			}
+
+			timeout := 2 * time.Minute
+			if err := f.WaitPodRunning(pod.ObjectMeta.Namespace, pod.ObjectMeta.Name, timeout); err != nil {
+				t.Fatalf("pod never reached state running")
+			}
+		})
 	}
 }
 
-func TestAutomountServiceAccountTokenRemoveDefault(t *testing.T) {
-	namespace, err := f.CreateTestNamespace()
-	if err != nil {
-		t.Fatalf("failed to create test namespace: %v", err)
-	}
-	namespace.ObjectMeta.Annotations = map[string]string{
-		"karydia.gardener.cloud/automountServiceAccountToken": "remove-default",
-	}
-	namespace, err = f.KubeClientset.CoreV1().Namespaces().Update(namespace)
-	if err != nil {
-		t.Fatalf("failed to annotate test namespace: %v", err)
+func stringifyTestCase(tc AutomountTokenTestCase) string {
+	var serviceAccount = tc.serviceAccount
+	var annotation string
+	var automountTokenPod string
+	var automountTokenServiceAccount string
+
+	if tc.nsAnnotation != nil {
+		annotation = *tc.nsAnnotation
+	} else {
+		annotation = "Undefined"
 	}
 
-	ns := namespace.ObjectMeta.Name
-
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "karydia-e2e-test-pod",
-			Namespace: ns,
-		},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{
-				{
-					Name:  "nginx",
-					Image: "nginx",
-				},
-			},
-		},
+	if tc.automountTokenServiceAccount != nil {
+		automountTokenServiceAccount = strconv.FormatBool(*tc.automountTokenServiceAccount)
+	} else {
+		automountTokenServiceAccount = "Undefined"
 	}
 
-	pod, err = f.KubeClientset.CoreV1().Pods(ns).Create(pod)
-	if err != nil {
-		t.Fatalf("failed to create pod: %v", err)
+	if tc.automountTokenPod != nil {
+		automountTokenPod = strconv.FormatBool(*tc.automountTokenPod)
+	} else {
+		automountTokenPod = "Undefined"
 	}
 
-	timeout := 2 * time.Minute
-	if err := f.WaitPodRunning(pod.ObjectMeta.Namespace, pod.ObjectMeta.Name, timeout); err != nil {
-		t.Fatalf("pod never reached state running")
-	}
-
-	if pod.Spec.AutomountServiceAccountToken == nil || *pod.Spec.AutomountServiceAccountToken {
-		t.Fatalf("pod's `automountServiceAccountToken` hasn't been set to `false` by default")
-	}
-	for _, vol := range pod.Spec.Volumes {
-		if strings.HasPrefix(vol.Name, "default-token-") {
-			t.Fatalf("pod has a default service account token mounted when it should not")
-		}
-	}
+	return fmt.Sprintf("%vServiceAccount%vAnnotation%vServiceAccountAutomount%vPodAutomount",
+		serviceAccount, annotation, automountTokenServiceAccount, automountTokenPod)
 }


### PR DESCRIPTION
<!-- Thanks for sending a PR -->

### Description
Introduces the secure-by-default options `change-default` and `change-all` for the automountServiceAccount feature and removes previous, prohibitive options. The admission controller now applies to ServiceAccount `Create` and `Update` events. Instead of admitting each pod, the default setting for `automountServiceAccountToken` is changed directly for each service account when not explicitly configured otherwise.

Fixes #98.


### Checklist
Before submitting this PR, please make sure:
- [x] you have added unit tests
- [x] you have added integration tests
- [x] your code builds clean with `make`
- [x] your code lets succeed unit tests with `make test`
- [x] your code lets succeed integration tests
- [x] you have documented new or changed features
<!-- Please delete options that are not relevant -->
