### PR TITLE
Fix nil pointer issue after restart of pod

### DIFF
--- a/cli/cmd/runserver.go
+++ b/cli/cmd/runserver.go
@@ -175,7 +175,7 @@ func runserverFunc(cmd *cobra.Command, args []string) {
 			fmt.Fprintf(os.Stderr, "Failed to unmarshal default network policy configmap ('%s:%s') into network policy object: %v\n", namespace, name, err)
 			os.Exit(1)
 		}
-		defaultNetworkPolicies[karydiaConfig.Spec.NetworkPolicy] = &policy
+		defaultNetworkPolicies[name] = &policy
 	}
 
 	var reconciler *controller.NetworkpolicyReconciler

--- a/pkg/controller/networkpolicy_reconciler_test.go
+++ b/pkg/controller/networkpolicy_reconciler_test.go
@@ -235,6 +235,29 @@ func TestReconcileNetworkPolicyDelete(t *testing.T) {
 	}
 }
 
+func TestReconcileNetworkPolicyWithExisting(t *testing.T) {
+	namespace := &coreV1.Namespace{}
+	namespace.Name = "default"
+	f := newFixture(t)
+	newNetworkPolicy := &networkingv1.NetworkPolicy{}
+	newNetworkPolicy.Name = "karydia-default-network-policy"
+	newNetworkPolicy.Namespace = "default"
+
+	f.kubeobjects = append(f.kubeobjects, namespace)
+
+	f.runReconcile(getKey(newNetworkPolicy, t))
+
+	reconciledPolicy, err := f.kubeclient.NetworkingV1().NetworkPolicies(newNetworkPolicy.Namespace).Get(newNetworkPolicy.Name, meta_v1.GetOptions{})
+	if err != nil {
+		t.Errorf("No error expected")
+	} else if !networkPoliciesAreEqual(f.defaultNetworkPolicies["karydia-default-network-policy"], reconciledPolicy) {
+		t.Errorf("No reconcilation happened")
+	}
+
+	f.defaultNetworkPolicies = make(map[string]*networkingv1.NetworkPolicy, 2)
+	f.runReconcile(getKey(newNetworkPolicy, t))
+}
+
 func TestReconcileNetworkPolicyCreateNamespace(t *testing.T) {
 	f := newFixture(t)
 	newNamespace := &coreV1.Namespace{}


### PR DESCRIPTION
<!-- Thanks for sending a PR -->

### Description
After karydia is restarted the network policy reconciler will lead to a nil pointer exception. This PR will make better checks and reloads the network policies if necessary.


### Checklist
Before submitting this PR, please make sure:
- [ ] you have added unit tests
- [ ] you have added integration tests
- [x] your code builds clean with `make`
- [x] your code lets succeed unit tests with `make test`
- [x] your code lets succeed integration tests
- [ ] you have documented new or changed features
<!-- Please delete options that are not relevant -->
