### PR TITLE
Add karydia config integration tests

### DIFF
--- a/tests/e2e/framework/framework.go
+++ b/tests/e2e/framework/framework.go
@@ -211,8 +211,8 @@ spec:
 			Name: "karydia-config",
 		},
 		Spec: v1alpha1.KarydiaConfigSpec{
-			AutomountServiceAccountToken: "",
-			SeccompProfile: "",
+			AutomountServiceAccountToken: "change-default",
+			SeccompProfile: "docker/default",
 			NetworkPolicy: "kube-system:karydia-default-network-policy",
 		},
 	}


### PR DESCRIPTION
<!-- Thanks for sending a PR -->

### Description
<!-- Feature description or reference to fixed issue -->
This changes the e2e karydia setup to prod deployment defaults and adds some karydia config integration tests.

### Checklist
Before submitting this PR, please make sure:
- [x] you have added integration tests
- [x] your code builds clean with `make`
- [x] your code lets succeed unit tests with `make test`
- [x] your code lets succeed integration tests
<!-- Please delete options that are not relevant -->
