### PR TITLE
Internal karydia feature annotations

### DIFF
--- a/pkg/admission/karydia/admission.go
+++ b/pkg/admission/karydia/admission.go
@@ -49,13 +49,21 @@ type Config struct {
 	KarydiaConfig *v1alpha1.KarydiaConfig
 }
 
+type Setting struct {
+	value string
+	src   string
+}
+
 type patchOperation struct {
 	Op    string      `json:"op"`
 	Path  string      `json:"path"`
 	Value interface{} `json:"value,omitempty"`
 }
 
-type patchOperations []patchOperation
+type Patches struct {
+	operations []patchOperation
+	annotated  bool
+}
 
 func New(config *Config) (*KarydiaAdmission, error) {
 	logger := logrus.New()
@@ -128,8 +136,8 @@ func (k *KarydiaAdmission) getNamespaceFromAdmissionRequest(ar v1beta1.Admission
 	return namespace, nil
 }
 
-func (patches *patchOperations) toBytes() []byte {
-	patchBytes, err := json.Marshal(patches)
+func (patches *Patches) toBytes() []byte {
+	patchBytes, err := json.Marshal(patches.operations)
 	if err != nil {
 		return nil
 	}

--- a/pkg/admission/karydia/admission_test.go
+++ b/pkg/admission/karydia/admission_test.go
@@ -86,9 +86,11 @@ func TestPodPlain(t *testing.T) {
 
 	var patches []patchOperation
 	err = json.Unmarshal(mutationResponse.Patch, &patches)
-	if len(patches) != 1 {
-		t.Errorf("expected number of patches to be 1 but is %v", len(patches))
+	if len(patches) != 2 {
+		t.Errorf("expected number of patches to be 2 but is %v", len(patches))
 	}
+
+	t.Log(patches)
 
 	mutatedPod, err := patchPodRaw(*pod, mutationResponse.Patch)
 	if err != nil {
@@ -97,14 +99,14 @@ func TestPodPlain(t *testing.T) {
 
 	validationResponse := karydiaAdmission.Admit(ar, false)
 	if validationResponse.Allowed {
-		t.Errorf("expected validation response to be false but is %v", mutationResponse.Allowed)
+		t.Errorf("expected validation response to be false but is %v", validationResponse.Allowed)
 	}
 
 	ar.Request.Object.Raw, _ = json.Marshal(mutatedPod)
 
 	validationResponse = karydiaAdmission.Admit(ar, false)
 	if !validationResponse.Allowed {
-		t.Errorf("expected validation response to be true but is %v", mutationResponse.Allowed)
+		t.Errorf("expected validation response to be true but is %v", validationResponse.Allowed)
 	}
 
 }
@@ -224,8 +226,8 @@ func TestServiceAccountPlain(t *testing.T) {
 
 	var patches []patchOperation
 	err = json.Unmarshal(mutationResponse.Patch, &patches)
-	if len(patches) != 1 {
-		t.Errorf("expected number of patches to be but is %v", len(patches))
+	if len(patches) != 2 {
+		t.Errorf("expected number of patches to be 2 but is %v", len(patches))
 	}
 
 	mutatedServiceAccount, err := patchServiceAccountRaw(*servieAccount, mutationResponse.Patch)
@@ -369,8 +371,8 @@ func TestServiceAccountDefault(t *testing.T) {
 
 	var patches []patchOperation
 	err = json.Unmarshal(mutationResponse.Patch, &patches)
-	if len(patches) != 1 {
-		t.Errorf("expected number of patches to be 1 but is %v", len(patches))
+	if len(patches) != 2 {
+		t.Errorf("expected number of patches to be 2 but is %v", len(patches))
 	}
 
 	mutatedServiceAccount, err := patchServiceAccountRaw(*servieAccount, mutationResponse.Patch)

--- a/pkg/admission/karydia/seccomp_test.go
+++ b/pkg/admission/karydia/seccomp_test.go
@@ -28,28 +28,30 @@ import (
  */
 func TestPodSeccompDefaultProfileWithAnnotation(t *testing.T) {
 	pod := corev1.Pod{}
-	var patches patchOperations
+	var patches Patches
 	var validationErrors []string
 
 	pod.Annotations = make(map[string]string)
 	pod.Annotations["seccomp.security.alpha.kubernetes.io/pod"] = "runtime/default"
 
-	patches = mutatePodSeccompProfile(pod, "runtime/default", patches)
-	if len(patches) != 0 {
-		t.Errorf("expected 0 patches but got: %+v", patches)
+	setting := Setting{value: "runtime/default", src: "namespace"}
+
+	patches = mutatePodSeccompProfile(pod, setting, patches)
+	if len(patches.operations) != 0 {
+		t.Errorf("expected 0 patches but got: %+v", patches.operations)
 	}
 	mutatedPod, err := patchPod(pod, patches)
 	if err != nil {
 		t.Errorf("failed to apply patches: %+v", err)
 	}
 	// Zero validation errors expected for mutated pod
-	validationErrors = validatePodSeccompProfile(mutatedPod, "runtime/default", validationErrors)
+	validationErrors = validatePodSeccompProfile(mutatedPod, setting, validationErrors)
 	if len(validationErrors) != 0 {
 		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
 	}
 	validationErrors = []string{}
 	// Zero validation error expected for initial pod
-	validationErrors = validatePodSeccompProfile(pod, "runtime/default", validationErrors)
+	validationErrors = validatePodSeccompProfile(pod, setting, validationErrors)
 	if len(validationErrors) != 0 {
 		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
 	}
@@ -57,25 +59,32 @@ func TestPodSeccompDefaultProfileWithAnnotation(t *testing.T) {
 
 func TestPodSeccompDefaultProfileNoAnnotation(t *testing.T) {
 	pod := corev1.Pod{}
-	var patches patchOperations
+	var patches Patches
 	var validationErrors []string
 
-	patches = mutatePodSeccompProfile(pod, "runtime/default", patches)
-	if len(patches) != 1 {
-		t.Errorf("expected 1 patches but got: %+v", patches)
+	setting := Setting{value: "runtime/default", src: "namespace"}
+
+	patches = mutatePodSeccompProfile(pod, setting, patches)
+	if len(patches.operations) != 2 {
+		t.Errorf("expected 2 patches but got: %+v", patches.operations)
 	}
+
+	t.Log(patches)
+
 	mutatedPod, err := patchPod(pod, patches)
 	if err != nil {
 		t.Errorf("failed to apply patches: %+v", err)
 	}
+
+	t.Log(mutatedPod)
 	// Zero validation errors expected for mutated pod
-	validationErrors = validatePodSeccompProfile(mutatedPod, "runtime/default", validationErrors)
+	validationErrors = validatePodSeccompProfile(mutatedPod, setting, validationErrors)
 	if len(validationErrors) != 0 {
 		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
 	}
 	validationErrors = []string{}
 	// One validation error expected for initial pod
-	validationErrors = validatePodSeccompProfile(pod, "runtime/default", validationErrors)
+	validationErrors = validatePodSeccompProfile(pod, setting, validationErrors)
 	if len(validationErrors) != 1 {
 		t.Errorf("expected 1 validationErrors but got: %+v", validationErrors)
 	}
@@ -83,28 +92,30 @@ func TestPodSeccompDefaultProfileNoAnnotation(t *testing.T) {
 
 func TestPodSeccompDefaultProfileOtherAnnotation(t *testing.T) {
 	pod := corev1.Pod{}
-	var patches patchOperations
+	var patches Patches
 	var validationErrors []string
+
+	setting := Setting{value: "runtime/default", src: "namespace"}
 
 	pod.Annotations = make(map[string]string)
 	pod.Annotations["seccomp.security.alpha.kubernetes.io/pod"] = "runtime/other"
 
-	patches = mutatePodSeccompProfile(pod, "runtime/default", patches)
-	if len(patches) != 0 {
-		t.Errorf("expected 0 patches but got: %+v", patches)
+	patches = mutatePodSeccompProfile(pod, setting, patches)
+	if len(patches.operations) != 0 {
+		t.Errorf("expected 0 patches but got: %+v", patches.operations)
 	}
 	mutatedPod, err := patchPod(pod, patches)
 	if err != nil {
 		t.Errorf("failed to apply patches: %+v", err)
 	}
 	// No validation error expected for mutated pod
-	validationErrors = validatePodSeccompProfile(mutatedPod, "runtime/default", validationErrors)
+	validationErrors = validatePodSeccompProfile(mutatedPod, setting, validationErrors)
 	if len(validationErrors) != 0 {
 		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
 	}
 	validationErrors = []string{}
 	// No validation error expected for initial pod
-	validationErrors = validatePodSeccompProfile(pod, "runtime/default", validationErrors)
+	validationErrors = validatePodSeccompProfile(pod, setting, validationErrors)
 	if len(validationErrors) != 0 {
 		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
 	}

--- a/pkg/admission/karydia/service_token_test.go
+++ b/pkg/admission/karydia/service_token_test.go
@@ -30,35 +30,36 @@ import (
  * kubectl annotate ns default karydia.gardener.cloud/automountServiceAccountToken=change-default
  */
 func TestServiceAccountChangeDefaultAnnotationDefaultServiceAccountMountUndefined(t *testing.T) {
-	var patches patchOperations
+	var patches Patches
 	var validationErrors []string
 
 	sAcc := corev1.ServiceAccount{}
 	sAcc.Name = "default"
 
-	patches = mutateServiceAccountTokenMount(sAcc, "change-default", patches)
-	if len(patches) != 1 {
-		t.Errorf("expected 1 patches but got: %+v", patches)
+	setting := Setting{value: "change-default", src: "namespace"}
+	patches = mutateServiceAccountTokenMount(sAcc, setting, patches)
+	if len(patches.operations) != 2 {
+		t.Errorf("expected 2 patches but got: %+v", patches.operations)
 	}
 	mutatedServiceAccount, err := patchServiceAccount(sAcc, patches)
 	if err != nil {
 		t.Errorf("failed to apply patches: %+v", err)
 	}
 	// Zero validation errors expected for mutated pod
-	validationErrors = validateServiceAccountTokenMount(mutatedServiceAccount, "change-default", validationErrors)
+	validationErrors = validateServiceAccountTokenMount(mutatedServiceAccount, setting, validationErrors)
 	if len(validationErrors) != 0 {
 		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
 	}
 	validationErrors = []string{}
 	// One validation error expected for initial pod
-	validationErrors = validateServiceAccountTokenMount(sAcc, "change-default", validationErrors)
+	validationErrors = validateServiceAccountTokenMount(sAcc, setting, validationErrors)
 	if len(validationErrors) != 1 {
 		t.Errorf("expected 1 validationErrors but got: %+v", validationErrors)
 	}
 }
 
 func TestServiceAccountChangeDefaultAnnotationDefaultServiceAccountMountFalse(t *testing.T) {
-	var patches patchOperations
+	var patches Patches
 	var validationErrors []string
 	var automount = false
 
@@ -66,29 +67,31 @@ func TestServiceAccountChangeDefaultAnnotationDefaultServiceAccountMountFalse(t 
 	sAcc.Name = "default"
 	sAcc.AutomountServiceAccountToken = &(automount)
 
-	patches = mutateServiceAccountTokenMount(sAcc, "change-default", patches)
-	if len(patches) != 0 {
-		t.Errorf("expected 0 patches but got: %+v", patches)
+	setting := Setting{value: "change-default", src: "namespace"}
+
+	patches = mutateServiceAccountTokenMount(sAcc, setting, patches)
+	if len(patches.operations) != 0 {
+		t.Errorf("expected 0 patches but got: %+v", patches.operations)
 	}
 	mutatedServiceAccount, err := patchServiceAccount(sAcc, patches)
 	if err != nil {
 		t.Errorf("failed to apply patches: %+v", err)
 	}
 	// Zero validation errors expected for mutated pod
-	validationErrors = validateServiceAccountTokenMount(mutatedServiceAccount, "change-default", validationErrors)
+	validationErrors = validateServiceAccountTokenMount(mutatedServiceAccount, setting, validationErrors)
 	if len(validationErrors) != 0 {
 		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
 	}
 	validationErrors = []string{}
 	// Zero validation errors expected for mutated pod
-	validationErrors = validateServiceAccountTokenMount(sAcc, "change-default", validationErrors)
+	validationErrors = validateServiceAccountTokenMount(sAcc, setting, validationErrors)
 	if len(validationErrors) != 0 {
 		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
 	}
 }
 
 func TestServiceAccountChangeDefaultAnnotationDefaultServiceAccountMountTrue(t *testing.T) {
-	var patches patchOperations
+	var patches Patches
 	var validationErrors []string
 	var automount = true
 
@@ -96,77 +99,83 @@ func TestServiceAccountChangeDefaultAnnotationDefaultServiceAccountMountTrue(t *
 	sAcc.Name = "default"
 	sAcc.AutomountServiceAccountToken = &(automount)
 
-	patches = mutateServiceAccountTokenMount(sAcc, "change-default", patches)
-	if len(patches) != 0 {
-		t.Errorf("expected 0 patches but got: %+v", patches)
+	setting := Setting{value: "change-default", src: "namespace"}
+
+	patches = mutateServiceAccountTokenMount(sAcc, setting, patches)
+	if len(patches.operations) != 0 {
+		t.Errorf("expected 0 patches but got: %+v", patches.operations)
 	}
 	mutatedServiceAccount, err := patchServiceAccount(sAcc, patches)
 	if err != nil {
 		t.Errorf("failed to apply patches: %+v", err)
 	}
 	// Zero validation errors expected for mutated pod
-	validationErrors = validateServiceAccountTokenMount(mutatedServiceAccount, "change-default", validationErrors)
+	validationErrors = validateServiceAccountTokenMount(mutatedServiceAccount, setting, validationErrors)
 	if len(validationErrors) != 0 {
 		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
 	}
 	validationErrors = []string{}
 	// Zero validation errors expected for mutated pod
-	validationErrors = validateServiceAccountTokenMount(sAcc, "change-default", validationErrors)
+	validationErrors = validateServiceAccountTokenMount(sAcc, setting, validationErrors)
 	if len(validationErrors) != 0 {
 		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
 	}
 }
 
 func TestServiceAccountChangeDefaultAnnotationSpecificServiceAccountMountUndefined(t *testing.T) {
-	var patches patchOperations
+	var patches Patches
 	var validationErrors []string
 
 	sAcc := corev1.ServiceAccount{}
 	sAcc.Name = "specific"
 
-	patches = mutateServiceAccountTokenMount(sAcc, "change-default", patches)
-	if len(patches) != 0 {
-		t.Errorf("expected 0 patches but got: %+v", patches)
+	setting := Setting{value: "change-default", src: "namespace"}
+
+	patches = mutateServiceAccountTokenMount(sAcc, setting, patches)
+	if len(patches.operations) != 0 {
+		t.Errorf("expected 0 patches but got: %+v", patches.operations)
 	}
 	mutatedServiceAccount, err := patchServiceAccount(sAcc, patches)
 	if err != nil {
 		t.Errorf("failed to apply patches: %+v", err)
 	}
 	// Zero validation errors expected for mutated pod
-	validationErrors = validateServiceAccountTokenMount(mutatedServiceAccount, "change-default", validationErrors)
+	validationErrors = validateServiceAccountTokenMount(mutatedServiceAccount, setting, validationErrors)
 	if len(validationErrors) != 0 {
 		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
 	}
 	validationErrors = []string{}
 	// Zero validation errors expected for mutated pod
-	validationErrors = validateServiceAccountTokenMount(sAcc, "change-default", validationErrors)
+	validationErrors = validateServiceAccountTokenMount(sAcc, setting, validationErrors)
 	if len(validationErrors) != 0 {
 		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
 	}
 }
 func TestServiceAccountRandomAnnotationDefaultServiceAccountMountUndefined(t *testing.T) {
-	var patches patchOperations
+	var patches Patches
 	var validationErrors []string
 
 	sAcc := corev1.ServiceAccount{}
 	sAcc.Name = "default"
 
-	patches = mutateServiceAccountTokenMount(sAcc, "random", patches)
-	if len(patches) != 0 {
-		t.Errorf("expected 0 patches but got: %+v", patches)
+	setting := Setting{value: "random", src: "namespace"}
+
+	patches = mutateServiceAccountTokenMount(sAcc, setting, patches)
+	if len(patches.operations) != 0 {
+		t.Errorf("expected 0 patches but got: %+v", patches.operations)
 	}
 	mutatedServiceAccount, err := patchServiceAccount(sAcc, patches)
 	if err != nil {
 		t.Errorf("failed to apply patches: %+v", err)
 	}
 	// Zero validation errors expected for mutated pod
-	validationErrors = validateServiceAccountTokenMount(mutatedServiceAccount, "random", validationErrors)
+	validationErrors = validateServiceAccountTokenMount(mutatedServiceAccount, setting, validationErrors)
 	if len(validationErrors) != 0 {
 		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
 	}
 	validationErrors = []string{}
 	// Zero validation errors expected for mutated pod
-	validationErrors = validateServiceAccountTokenMount(sAcc, "random", validationErrors)
+	validationErrors = validateServiceAccountTokenMount(sAcc, setting, validationErrors)
 	if len(validationErrors) != 0 {
 		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
 	}
@@ -178,63 +187,67 @@ func TestServiceAccountRandomAnnotationDefaultServiceAccountMountUndefined(t *te
  * kubectl annotate ns default karydia.gardener.cloud/automountServiceAccountToken=change-all
  */
 func TestServiceAccountChangeAllAnnotationDefaultServiceAccountMountUndefined(t *testing.T) {
-	var patches patchOperations
+	var patches Patches
 	var validationErrors []string
 
 	sAcc := corev1.ServiceAccount{}
 	sAcc.Name = "default"
 
-	patches = mutateServiceAccountTokenMount(sAcc, "change-all", patches)
-	if len(patches) != 1 {
-		t.Errorf("expected 1 patches but got: %+v", patches)
+	setting := Setting{value: "change-all", src: "namespace"}
+
+	patches = mutateServiceAccountTokenMount(sAcc, setting, patches)
+	if len(patches.operations) != 2 {
+		t.Errorf("expected 2 patches but got: %+v", patches.operations)
 	}
 	mutatedServiceAccount, err := patchServiceAccount(sAcc, patches)
 	if err != nil {
 		t.Errorf("failed to apply patches: %+v", err)
 	}
 	// Zero validation errors expected for mutated pod
-	validationErrors = validateServiceAccountTokenMount(mutatedServiceAccount, "change-all", validationErrors)
+	validationErrors = validateServiceAccountTokenMount(mutatedServiceAccount, setting, validationErrors)
 	if len(validationErrors) != 0 {
 		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
 	}
 	validationErrors = []string{}
 	// One validation error expected for initial pod
-	validationErrors = validateServiceAccountTokenMount(sAcc, "change-all", validationErrors)
+	validationErrors = validateServiceAccountTokenMount(sAcc, setting, validationErrors)
 	if len(validationErrors) != 1 {
 		t.Errorf("expected 1 validationErrors but got: %+v", validationErrors)
 	}
 }
 
 func TestServiceAccountChangeAllAnnotationSpecificServiceAccountMountUndefined(t *testing.T) {
-	var patches patchOperations
+	var patches Patches
 	var validationErrors []string
 
 	sAcc := corev1.ServiceAccount{}
 	sAcc.Name = "specific"
 
-	patches = mutateServiceAccountTokenMount(sAcc, "change-all", patches)
-	if len(patches) != 1 {
-		t.Errorf("expected 1 patches but got: %+v", patches)
+	setting := Setting{value: "change-all", src: "namespace"}
+
+	patches = mutateServiceAccountTokenMount(sAcc, setting, patches)
+	if len(patches.operations) != 2 {
+		t.Errorf("expected 2 patches but got: %+v", patches.operations)
 	}
 	mutatedServiceAccount, err := patchServiceAccount(sAcc, patches)
 	if err != nil {
 		t.Errorf("failed to apply patches: %+v", err)
 	}
 	// Zero validation errors expected for mutated pod
-	validationErrors = validateServiceAccountTokenMount(mutatedServiceAccount, "change-all", validationErrors)
+	validationErrors = validateServiceAccountTokenMount(mutatedServiceAccount, setting, validationErrors)
 	if len(validationErrors) != 0 {
 		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
 	}
 	validationErrors = []string{}
 	// One validation error expected for initial pod
-	validationErrors = validateServiceAccountTokenMount(sAcc, "change-all", validationErrors)
+	validationErrors = validateServiceAccountTokenMount(sAcc, setting, validationErrors)
 	if len(validationErrors) != 1 {
 		t.Errorf("expected 1 validationErrors but got: %+v", validationErrors)
 	}
 }
 
 func TestServiceAccountChangeAllAnnotationSpecificServiceAccountMountFalse(t *testing.T) {
-	var patches patchOperations
+	var patches Patches
 	var validationErrors []string
 	var automount = false
 
@@ -242,29 +255,31 @@ func TestServiceAccountChangeAllAnnotationSpecificServiceAccountMountFalse(t *te
 	sAcc.Name = "specific"
 	sAcc.AutomountServiceAccountToken = &(automount)
 
-	patches = mutateServiceAccountTokenMount(sAcc, "change-all", patches)
-	if len(patches) != 0 {
-		t.Errorf("expected 0 patches but got: %+v", patches)
+	setting := Setting{value: "change-all", src: "namespace"}
+
+	patches = mutateServiceAccountTokenMount(sAcc, setting, patches)
+	if len(patches.operations) != 0 {
+		t.Errorf("expected 0 patches but got: %+v", patches.operations)
 	}
 	mutatedServiceAccount, err := patchServiceAccount(sAcc, patches)
 	if err != nil {
 		t.Errorf("failed to apply patches: %+v", err)
 	}
 	// Zero validation errors expected for mutated pod
-	validationErrors = validateServiceAccountTokenMount(mutatedServiceAccount, "change-all", validationErrors)
+	validationErrors = validateServiceAccountTokenMount(mutatedServiceAccount, setting, validationErrors)
 	if len(validationErrors) != 0 {
 		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
 	}
 	validationErrors = []string{}
 	// Zero validation errors expected for mutated pod
-	validationErrors = validateServiceAccountTokenMount(sAcc, "change-all", validationErrors)
+	validationErrors = validateServiceAccountTokenMount(sAcc, setting, validationErrors)
 	if len(validationErrors) != 0 {
 		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
 	}
 }
 
 func TestServiceAccountChangeAllAnnotationspecificServiceAccountMountTrue(t *testing.T) {
-	var patches patchOperations
+	var patches Patches
 	var validationErrors []string
 	var automount = true
 
@@ -272,57 +287,61 @@ func TestServiceAccountChangeAllAnnotationspecificServiceAccountMountTrue(t *tes
 	sAcc.Name = "specific"
 	sAcc.AutomountServiceAccountToken = &(automount)
 
-	patches = mutateServiceAccountTokenMount(sAcc, "change-all", patches)
-	if len(patches) != 0 {
-		t.Errorf("expected 0 patches but got: %+v", patches)
+	setting := Setting{value: "change-all", src: "namespace"}
+
+	patches = mutateServiceAccountTokenMount(sAcc, setting, patches)
+	if len(patches.operations) != 0 {
+		t.Errorf("expected 0 patches but got: %+v", patches.operations)
 	}
 	mutatedServiceAccount, err := patchServiceAccount(sAcc, patches)
 	if err != nil {
 		t.Errorf("failed to apply patches: %+v", err)
 	}
 	// Zero validation errors expected for mutated pod
-	validationErrors = validateServiceAccountTokenMount(mutatedServiceAccount, "change-all", validationErrors)
+	validationErrors = validateServiceAccountTokenMount(mutatedServiceAccount, setting, validationErrors)
 	if len(validationErrors) != 0 {
 		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
 	}
 	validationErrors = []string{}
 	// Zero validation errors expected for mutated pod
-	validationErrors = validateServiceAccountTokenMount(sAcc, "change-all", validationErrors)
+	validationErrors = validateServiceAccountTokenMount(sAcc, setting, validationErrors)
 	if len(validationErrors) != 0 {
 		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
 	}
 }
 
 func TestServiceAccountRandomAnnotationSpecificServiceAccountMountUndefined(t *testing.T) {
-	var patches patchOperations
+	var patches Patches
 	var validationErrors []string
 
 	sAcc := corev1.ServiceAccount{}
 	sAcc.Name = "specific"
 
-	patches = mutateServiceAccountTokenMount(sAcc, "random", patches)
-	if len(patches) != 0 {
-		t.Errorf("expected 0 patches but got: %+v", patches)
+	setting := Setting{value: "random", src: "namespace"}
+
+	patches = mutateServiceAccountTokenMount(sAcc, setting, patches)
+	if len(patches.operations) != 0 {
+		t.Errorf("expected 0 patches but got: %+v", patches.operations)
 	}
 	mutatedServiceAccount, err := patchServiceAccount(sAcc, patches)
 	if err != nil {
 		t.Errorf("failed to apply patches: %+v", err)
 	}
 	// Zero validation errors expected for mutated pod
-	validationErrors = validateServiceAccountTokenMount(mutatedServiceAccount, "random", validationErrors)
+	validationErrors = validateServiceAccountTokenMount(mutatedServiceAccount, setting, validationErrors)
 	if len(validationErrors) != 0 {
 		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
 	}
 	validationErrors = []string{}
 	// Zero validation errors expected for mutated pod
-	validationErrors = validateServiceAccountTokenMount(sAcc, "random", validationErrors)
+	validationErrors = validateServiceAccountTokenMount(sAcc, setting, validationErrors)
 	if len(validationErrors) != 0 {
 		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
 	}
 }
 
 /* Helper functions */
-func patchPod(pod corev1.Pod, patches patchOperations) (corev1.Pod, error) {
+func patchPod(pod corev1.Pod, patches Patches) (corev1.Pod, error) {
 	var podJSON []byte
 	podJSON, err := json.Marshal(&pod)
 	if err != nil {
@@ -344,7 +363,7 @@ func patchPod(pod corev1.Pod, patches patchOperations) (corev1.Pod, error) {
 	return podPatched, nil
 }
 
-func patchServiceAccount(sAcc corev1.ServiceAccount, patches patchOperations) (corev1.ServiceAccount, error) {
+func patchServiceAccount(sAcc corev1.ServiceAccount, patches Patches) (corev1.ServiceAccount, error) {
 	var podJSON []byte
 	podJSON, err := json.Marshal(&sAcc)
 	if err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a PR -->

### Description
These annotations allow to indentify the source and value
of each security setting that is applied by karydia. In case
of race-conditions this helps to identify the current state
and where settings have to be updated.

### Checklist
Before submitting this PR, please make sure:
- [x] you have added unit tests
- [x] your code builds clean with `make`
- [x] your code lets succeed unit tests with `make test`
- [x] your code lets succeed integration tests
- [ ] you have documented new or changed features
<!-- Please delete options that are not relevant -->
