### PR TITLE
Alpine base image for production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ COPY --from=build-stage /go/src/github.com/karydia/karydia/bin/karydia /usr/loca
 COPY ./scripts/hotswap-dev /usr/local/bin/hotswap-dev
 
 # prod-image (production usage)
-FROM k8s.gcr.io/debian-base-amd64:1.0.0 as prod-image
+FROM alpine:3.9 as prod-image
 COPY --from=build-stage /go/src/github.com/karydia/karydia/bin/karydia /usr/local/bin/karydia
 USER 65534:65534
 


### PR DESCRIPTION
<!-- Thanks for sending a PR -->

### Description
Alpine replaces Debian as base-image for our prod-image. Running our binary from `scratch` brings complications with the logging frameworks that require certain directories with file access. This change still reduces the prod-image size by roughly 60%.

Alpine 3.9 is approved as a base-image by SAP.

Fixes #80.


### Checklist
Before submitting this PR, please make sure:
- [x] your code builds clean with `make`
- [x] your code lets succeed unit tests with `make test`
- [x] your code lets succeed integration tests
<!-- Please delete options that are not relevant -->
