### PR TITLE
Run gofmt with make test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,9 +59,19 @@ debug-dev:
 codegen:
 	hack/update-codegen.sh
 
-.PHONY: test
-test:
+.PHONY: test-only
+test-only:
 	go test $(shell go list ./... | grep -v /vendor/ | grep -v /tests/)
+
+.PHONY: fmt
+fmt:
+	@if [ -n "$(shell gofmt -l pkg cli tests)" ]; then \
+    		echo "Go code is not formatted!";\
+    		exit 1;\
+	fi
+
+.PHONY: test
+test: fmt test-only
 
 .PHONY: test-coverage
 test-coverage:

--- a/cli/cmd/runserver.go
+++ b/cli/cmd/runserver.go
@@ -122,18 +122,18 @@ func runserverFunc(cmd *cobra.Command, args []string) {
 
 	cfg, err := clientcmd.BuildConfigFromFlags(kubeServer, kubeConfig)
 	if err != nil {
-		fmt.Fprintf(os.Stderr,"Failed to build kubeconfig: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Failed to build kubeconfig: %v\n", err)
 		os.Exit(1)
 	}
 	karydiaClientset, err := clientset.NewForConfig(cfg)
 	if err != nil {
-		fmt.Fprintf(os.Stderr,"Failed to build karydia clientset: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Failed to build karydia clientset: %v\n", err)
 		os.Exit(1)
 	}
 
 	karydiaConfig, err := karydiaClientset.KarydiaV1alpha1().KarydiaConfigs().Get(viper.GetString("config"), metav1.GetOptions{})
 	if err != nil {
-		fmt.Fprintf(os.Stderr,"Failed to load karydia config: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Failed to load karydia config: %v\n", err)
 		os.Exit(1)
 	}
 	fmt.Fprintf(os.Stdout, "KarydiaConfig Name: %s\n", karydiaConfig.Name)

--- a/pkg/apis/karydia/v1alpha1/types.go
+++ b/pkg/apis/karydia/v1alpha1/types.go
@@ -40,7 +40,6 @@ type KarydiaConfigSpec struct {
 	// SeccompProfile can be used to set a default seccomp profile
 	SeccompProfile string `json:"seccompProfile"`
 
-
 	// NetworkPolicy can be used to set a default network policy
 	NetworkPolicy string `json:"networkPolicy"`
 }

--- a/pkg/controller/config_reconciler.go
+++ b/pkg/controller/config_reconciler.go
@@ -35,28 +35,28 @@ import (
 
 // reconciler (controller) struct
 type ConfigReconciler struct {
-	config		v1alpha1.KarydiaConfig
-	controllers	[]ControllerInterface
+	config      v1alpha1.KarydiaConfig
+	controllers []ControllerInterface
 
 	// clientset for own API group
-	clientset	versioned.Interface
-	lister		v1alpha13.KarydiaConfigLister
-	synced		cache.InformerSynced
+	clientset versioned.Interface
+	lister    v1alpha13.KarydiaConfigLister
+	synced    cache.InformerSynced
 	// rate limited work queue
 	// This is used to queue work to be processed instead of performing it as
 	// soon as a change happens. This means we can ensure we only process a
 	// fixed amount of resources at a time, and makes it easy to ensure we are
 	// never processing the same item simultaneously in two different workers.
-	workqueue	workqueue.RateLimitingInterface
+	workqueue workqueue.RateLimitingInterface
 }
 
 // reconciler (controller) setup
-func NewConfigReconciler (
-	karydiaConfig			v1alpha1.KarydiaConfig,
-	karydiaControllers		[]ControllerInterface,
-	karydiaClientset		versioned.Interface,
-	karydiaConfigInformer	v1alpha12.KarydiaConfigInformer,
-	) *ConfigReconciler {
+func NewConfigReconciler(
+	karydiaConfig v1alpha1.KarydiaConfig,
+	karydiaControllers []ControllerInterface,
+	karydiaClientset versioned.Interface,
+	karydiaConfigInformer v1alpha12.KarydiaConfigInformer,
+) *ConfigReconciler {
 	reconciler := &ConfigReconciler{
 		config:      karydiaConfig,
 		controllers: karydiaControllers,

--- a/pkg/controller/config_reconciler_test.go
+++ b/pkg/controller/config_reconciler_test.go
@@ -43,6 +43,7 @@ type testSettings struct {
 	sharedInformerFactory externalversions.SharedInformerFactory
 	waitTimeoutSeconds    time.Duration
 }
+
 func newTestSettings(t *testing.T, kubeObjects []runtime.Object, karydiaControllers []ControllerInterface) *testSettings {
 	clientset := fake.NewSimpleClientset(kubeObjects...)
 	sharedInformerFactory := externalversions.NewSharedInformerFactory(clientset, noResyncPeriodFunc())
@@ -58,27 +59,28 @@ func newTestSettings(t *testing.T, kubeObjects []runtime.Object, karydiaControll
 }
 
 type testConfigParams struct {
-	automountServiceAccountToken	string
-	seccompProfile					string
-	networkPolicy					string
+	automountServiceAccountToken string
+	seccompProfile               string
+	networkPolicy                string
 }
 type testConfig struct {
-	t		*testing.T
-	config	v1alpha1.KarydiaConfig
+	t      *testing.T
+	config v1alpha1.KarydiaConfig
 }
+
 func newTestConfig(t *testing.T, resourceVersion string, params testConfigParams) *testConfig {
 	configName := "testConfig"
 	return &testConfig{
 		t: t,
 		config: v1alpha1.KarydiaConfig{
 			ObjectMeta: meta_v1.ObjectMeta{
-				Name: configName,
+				Name:            configName,
 				ResourceVersion: resourceVersion,
 			},
 			Spec: v1alpha1.KarydiaConfigSpec{
 				AutomountServiceAccountToken: params.automountServiceAccountToken,
-				SeccompProfile: params.seccompProfile,
-				NetworkPolicy: params.networkPolicy,
+				SeccompProfile:               params.seccompProfile,
+				NetworkPolicy:                params.networkPolicy,
 			},
 		},
 	}
@@ -89,10 +91,11 @@ type testControllerInterface interface {
 	isUpdated() bool
 }
 type testController struct {
-	name				string
-	updated				bool
-	updateError			error
+	name        string
+	updated     bool
+	updateError error
 }
+
 func (c *testController) UpdateConfig(karydiaConfig v1alpha1.KarydiaConfig) error {
 	if c.updateError != nil {
 		c.updated = false
@@ -109,9 +112,9 @@ func TestNewConfigReconciler(t *testing.T) {
 	// setup
 	assert := assert.New(t)
 	c := newTestConfig(t, "1", testConfigParams{
-		automountServiceAccountToken:	"testAutomountServiceAccountToken",
-		seccompProfile:					"testSeccompProfile",
-		networkPolicy:					"testNetworkPolicy",
+		automountServiceAccountToken: "testAutomountServiceAccountToken",
+		seccompProfile:               "testSeccompProfile",
+		networkPolicy:                "testNetworkPolicy",
 	})
 	s := newTestSettings(t, []runtime.Object{}, []ControllerInterface{new(testController)})
 
@@ -141,9 +144,9 @@ func TestConfigReconciler_syncConfigHandlerWithoutConfigElement(t *testing.T) {
 	// setup
 	assert := assert.New(t)
 	c := newTestConfig(t, "1", testConfigParams{
-		automountServiceAccountToken:	"testAutomountServiceAccountToken",
-		seccompProfile:					"testSeccompProfile",
-		networkPolicy:					"testNetworkPolicy",
+		automountServiceAccountToken: "testAutomountServiceAccountToken",
+		seccompProfile:               "testSeccompProfile",
+		networkPolicy:                "testNetworkPolicy",
 	})
 	s := newTestSettings(t, []runtime.Object{}, []ControllerInterface{})
 	r := NewConfigReconciler(c.config, s.controllers, s.clientset, s.configInformer)
@@ -174,9 +177,9 @@ func TestConfigReconciler_enqueueConfig(t *testing.T) {
 	// setup
 	assert := assert.New(t)
 	c := newTestConfig(t, "1", testConfigParams{
-		automountServiceAccountToken:	"testAutomountServiceAccountToken",
-		seccompProfile:					"testSeccompProfile",
-		networkPolicy:					"testNetworkPolicy",
+		automountServiceAccountToken: "testAutomountServiceAccountToken",
+		seccompProfile:               "testSeccompProfile",
+		networkPolicy:                "testNetworkPolicy",
 	})
 	s := newTestSettings(t, []runtime.Object{}, []ControllerInterface{})
 	r := NewConfigReconciler(c.config, s.controllers, s.clientset, s.configInformer)
@@ -202,9 +205,9 @@ func TestConfigReconciler_reconcileIsNeeded(t *testing.T) {
 	// setup
 	assert := assert.New(t)
 	c := newTestConfig(t, "1", testConfigParams{
-		automountServiceAccountToken:	"testAutomountServiceAccountToken",
-		seccompProfile:					"testSeccompProfile",
-		networkPolicy:					"testNetworkPolicy",
+		automountServiceAccountToken: "testAutomountServiceAccountToken",
+		seccompProfile:               "testSeccompProfile",
+		networkPolicy:                "testNetworkPolicy",
 	})
 	s := newTestSettings(t, []runtime.Object{}, []ControllerInterface{})
 	r := NewConfigReconciler(c.config, s.controllers, s.clientset, s.configInformer)
@@ -226,9 +229,9 @@ func TestConfigReconciler_UpdateConfigWithoutControllers(t *testing.T) {
 	// setup
 	assert := assert.New(t)
 	c := newTestConfig(t, "1", testConfigParams{
-		automountServiceAccountToken:	"testAutomountServiceAccountToken",
-		seccompProfile:					"testSeccompProfile",
-		networkPolicy:					"testNetworkPolicy",
+		automountServiceAccountToken: "testAutomountServiceAccountToken",
+		seccompProfile:               "testSeccompProfile",
+		networkPolicy:                "testNetworkPolicy",
 	})
 	s := newTestSettings(t, []runtime.Object{}, []ControllerInterface{})
 	r := NewConfigReconciler(c.config, s.controllers, s.clientset, s.configInformer)
@@ -253,9 +256,9 @@ func TestConfigReconciler_UpdateConfigWithController(t *testing.T) {
 	// setup
 	assert := assert.New(t)
 	c := newTestConfig(t, "1", testConfigParams{
-		automountServiceAccountToken:	"testAutomountServiceAccountToken",
-		seccompProfile:					"testSeccompProfile",
-		networkPolicy:					"testNetworkPolicy",
+		automountServiceAccountToken: "testAutomountServiceAccountToken",
+		seccompProfile:               "testSeccompProfile",
+		networkPolicy:                "testNetworkPolicy",
 	})
 	s := newTestSettings(t, []runtime.Object{}, []ControllerInterface{new(testController)})
 	r := NewConfigReconciler(c.config, s.controllers, s.clientset, s.configInformer)
@@ -296,9 +299,9 @@ func TestConfigReconciler_UpdateConfigWithControllers(t *testing.T) {
 	// setup
 	assert := assert.New(t)
 	c := newTestConfig(t, "1", testConfigParams{
-		automountServiceAccountToken:	"testAutomountServiceAccountToken",
-		seccompProfile:					"testSeccompProfile",
-		networkPolicy:					"testNetworkPolicy",
+		automountServiceAccountToken: "testAutomountServiceAccountToken",
+		seccompProfile:               "testSeccompProfile",
+		networkPolicy:                "testNetworkPolicy",
 	})
 	controller0 := testController{name: "testController0"}
 	controller1 := testController{name: "testController1"}
@@ -350,9 +353,9 @@ func TestConfigReconciler_UpdateConfigWithControllersAndError(t *testing.T) {
 	// setup
 	assert := assert.New(t)
 	c := newTestConfig(t, "1", testConfigParams{
-		automountServiceAccountToken:	"testAutomountServiceAccountToken",
-		seccompProfile:					"testSeccompProfile",
-		networkPolicy:					"testNetworkPolicy",
+		automountServiceAccountToken: "testAutomountServiceAccountToken",
+		seccompProfile:               "testSeccompProfile",
+		networkPolicy:                "testNetworkPolicy",
 	})
 	controller0 := testController{name: "testController0"}
 	controller1 := testController{name: "testController1", updateError: fmt.Errorf("test config update error")}
@@ -404,9 +407,9 @@ func TestConfigReconciler_createConfig(t *testing.T) {
 	// setup
 	assert := assert.New(t)
 	c := newTestConfig(t, "1", testConfigParams{
-		automountServiceAccountToken:	"testAutomountServiceAccountToken",
-		seccompProfile:					"testSeccompProfile",
-		networkPolicy:					"testNetworkPolicy",
+		automountServiceAccountToken: "testAutomountServiceAccountToken",
+		seccompProfile:               "testSeccompProfile",
+		networkPolicy:                "testNetworkPolicy",
 	})
 	s := newTestSettings(t, []runtime.Object{}, []ControllerInterface{})
 	r := NewConfigReconciler(c.config, s.controllers, s.clientset, s.configInformer)
@@ -426,14 +429,14 @@ func TestConfigReconciler_RunWithoutStartConfig(t *testing.T) {
 	// setup
 	assert := assert.New(t)
 	c := newTestConfig(t, "1", testConfigParams{
-		automountServiceAccountToken:	"testAutomountServiceAccountToken",
-		seccompProfile:					"testSeccompProfile",
-		networkPolicy:					"testNetworkPolicy",
+		automountServiceAccountToken: "testAutomountServiceAccountToken",
+		seccompProfile:               "testSeccompProfile",
+		networkPolicy:                "testNetworkPolicy",
 	})
 	newC := newTestConfig(t, "2", testConfigParams{
-		automountServiceAccountToken:	"testAutomountServiceAccountToken",
-		seccompProfile:					"newValue",
-		networkPolicy:					"testNetworkPolicy",
+		automountServiceAccountToken: "testAutomountServiceAccountToken",
+		seccompProfile:               "newValue",
+		networkPolicy:                "testNetworkPolicy",
 	})
 	s := newTestSettings(t, []runtime.Object{}, []ControllerInterface{new(testController)})
 	r := NewConfigReconciler(c.config, s.controllers, s.clientset, s.configInformer)
@@ -482,7 +485,7 @@ func TestConfigReconciler_RunWithoutStartConfig(t *testing.T) {
 	assert.NoError(err)
 	// with cache update
 	s.sharedInformerFactory.WaitForCacheSync(ctx.Done())
-	if err := wait.PollImmediate(1 * time.Millisecond, s.waitTimeoutSeconds, func()(bool, error) {
+	if err := wait.PollImmediate(1*time.Millisecond, s.waitTimeoutSeconds, func() (bool, error) {
 		_, err := r.lister.Get(c.config.Name)
 		if errors.IsNotFound(err) {
 			return false, nil
@@ -505,19 +508,19 @@ func TestConfigReconciler_RunWithStartConfig(t *testing.T) {
 	// setup
 	assert := assert.New(t)
 	c := newTestConfig(t, "1", testConfigParams{
-		automountServiceAccountToken:	"testAutomountServiceAccountToken",
-		seccompProfile:					"testSeccompProfile",
-		networkPolicy:					"testNetworkPolicy",
+		automountServiceAccountToken: "testAutomountServiceAccountToken",
+		seccompProfile:               "testSeccompProfile",
+		networkPolicy:                "testNetworkPolicy",
 	})
 	newC := newTestConfig(t, "1", testConfigParams{
-		automountServiceAccountToken:	"testAutomountServiceAccountToken",
-		seccompProfile:					"testSeccompProfile",
-		networkPolicy:					"newValue",
+		automountServiceAccountToken: "testAutomountServiceAccountToken",
+		seccompProfile:               "testSeccompProfile",
+		networkPolicy:                "newValue",
 	})
 	differentC := newTestConfig(t, "2", testConfigParams{
-		automountServiceAccountToken:	"testAutomountServiceAccountToken",
-		seccompProfile:					"testSeccompProfile",
-		networkPolicy:					"differentValue",
+		automountServiceAccountToken: "testAutomountServiceAccountToken",
+		seccompProfile:               "testSeccompProfile",
+		networkPolicy:                "differentValue",
 	})
 	s := newTestSettings(t, []runtime.Object{&c.config}, []ControllerInterface{new(testController)})
 	r := NewConfigReconciler(c.config, s.controllers, s.clientset, s.configInformer)
@@ -542,7 +545,7 @@ func TestConfigReconciler_RunWithStartConfig(t *testing.T) {
 	assert.True(errors.IsAlreadyExists(err))
 	// but without cache update because operation failed
 	s.sharedInformerFactory.WaitForCacheSync(ctx.Done())
-	if err := wait.PollImmediate(1 * time.Millisecond, s.waitTimeoutSeconds, func()(bool, error) {
+	if err := wait.PollImmediate(1*time.Millisecond, s.waitTimeoutSeconds, func() (bool, error) {
 		_, err := r.lister.Get(c.config.Name)
 		if errors.IsNotFound(err) {
 			return false, nil
@@ -604,7 +607,7 @@ func TestConfigReconciler_RunWithStartConfig(t *testing.T) {
 	assert.False(controller.updated)
 	// and re-synced cache
 	s.sharedInformerFactory.WaitForCacheSync(ctx.Done())
-	if err := wait.PollImmediate(1 * time.Millisecond, s.waitTimeoutSeconds, func()(bool, error) {
+	if err := wait.PollImmediate(1*time.Millisecond, s.waitTimeoutSeconds, func() (bool, error) {
 		_, err := r.lister.Get(c.config.Name)
 		if errors.IsNotFound(err) {
 			return false, nil
@@ -624,14 +627,14 @@ func TestConfigReconciler_RunWithStartConfigAndWorkingWithDifferentConfig(t *tes
 	// setup
 	assert := assert.New(t)
 	c := newTestConfig(t, "1", testConfigParams{
-		automountServiceAccountToken:	"testAutomountServiceAccountToken",
-		seccompProfile:					"testSeccompProfile",
-		networkPolicy:					"testNetworkPolicy",
+		automountServiceAccountToken: "testAutomountServiceAccountToken",
+		seccompProfile:               "testSeccompProfile",
+		networkPolicy:                "testNetworkPolicy",
 	})
 	differentC := newTestConfig(t, "2", testConfigParams{
-		automountServiceAccountToken:	"differentAutomountServiceAccountToken",
-		seccompProfile:					"differentSeccompProfile",
-		networkPolicy:					"differentNetworkPolicy",
+		automountServiceAccountToken: "differentAutomountServiceAccountToken",
+		seccompProfile:               "differentSeccompProfile",
+		networkPolicy:                "differentNetworkPolicy",
 	})
 	differentC.config.Name = "differentName"
 	s := newTestSettings(t, []runtime.Object{&c.config}, []ControllerInterface{new(testController)})
@@ -661,7 +664,7 @@ func TestConfigReconciler_RunWithStartConfigAndWorkingWithDifferentConfig(t *tes
 	assert.NoError(err)
 	assert.Equal(&differentC.config, e)
 	s.sharedInformerFactory.WaitForCacheSync(ctx.Done())
-	if err := wait.PollImmediate(1 * time.Millisecond, s.waitTimeoutSeconds, func()(bool, error) {
+	if err := wait.PollImmediate(1*time.Millisecond, s.waitTimeoutSeconds, func() (bool, error) {
 		_, err := r.lister.Get(c.config.Name)
 		if errors.IsNotFound(err) {
 			return false, nil
@@ -670,7 +673,7 @@ func TestConfigReconciler_RunWithStartConfigAndWorkingWithDifferentConfig(t *tes
 	}); err != nil {
 		t.FailNow()
 	}
-	if err := wait.PollImmediate(1 * time.Millisecond, s.waitTimeoutSeconds, func()(bool, error) {
+	if err := wait.PollImmediate(1*time.Millisecond, s.waitTimeoutSeconds, func() (bool, error) {
 		_, err := r.lister.Get(differentC.config.Name)
 		if errors.IsNotFound(err) {
 			return false, nil

--- a/pkg/controller/networkpolicy_reconciler_test.go
+++ b/pkg/controller/networkpolicy_reconciler_test.go
@@ -152,7 +152,7 @@ func TestNetworkpolicyReconciler_UpdateConfig(t *testing.T) {
 	validNetworkPolicy := "ns:" + networkPolicyNames[2]
 	newConfig := v1alpha1.KarydiaConfig{
 		ObjectMeta: meta_v1.ObjectMeta{
-			Name: "testConfig",
+			Name:            "testConfig",
 			ResourceVersion: "1",
 		},
 		Spec: v1alpha1.KarydiaConfigSpec{

--- a/tests/e2e/framework/framework.go
+++ b/tests/e2e/framework/framework.go
@@ -52,8 +52,8 @@ import (
 )
 
 type Framework struct {
-	KubeClientset kubernetes.Interface
-	ApiExtClientset apiextension.Interface
+	KubeClientset    kubernetes.Interface
+	ApiExtClientset  apiextension.Interface
 	KarydiaClientset versioned.Interface
 
 	Namespace string
@@ -66,25 +66,25 @@ func Setup(server, kubeconfig, namespace string) (*Framework, error) {
 	}
 	cfg, err := clientcmd.BuildConfigFromFlags(server, kubeconfig)
 	if err != nil {
-		fmt.Fprintf(os.Stderr,"Failed to build kubeconfig: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Failed to build kubeconfig: %v\n", err)
 		os.Exit(1)
 	}
 	ApiExtClientset, err := apiextension.NewForConfig(cfg)
 	if err != nil {
-		fmt.Fprintf(os.Stderr,"Failed to build api extension clientset: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Failed to build api extension clientset: %v\n", err)
 		os.Exit(1)
 	}
 	KarydiaClientset, err := clientset.NewForConfig(cfg)
 	if err != nil {
-		fmt.Fprintf(os.Stderr,"Failed to build karydia clientset: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Failed to build karydia clientset: %v\n", err)
 		os.Exit(1)
 	}
 
 	return &Framework{
-		KubeClientset: KubeClientset,
-		ApiExtClientset: ApiExtClientset,
+		KubeClientset:    KubeClientset,
+		ApiExtClientset:  ApiExtClientset,
 		KarydiaClientset: KarydiaClientset,
-		Namespace:     namespace,
+		Namespace:        namespace,
 	}, nil
 }
 
@@ -192,7 +192,7 @@ spec:
 	if err != nil {
 		return fmt.Errorf("failed to create: %v", crdObject)
 	}
-	if err := wait.Poll(1 * time.Second, 20 * time.Second, func()(bool, error) {
+	if err := wait.Poll(1*time.Second, 20*time.Second, func() (bool, error) {
 		_, err := f.ApiExtClientset.ApiextensionsV1beta1().CustomResourceDefinitions().Get(crdObject.Name, metav1.GetOptions{})
 		if errors.IsNotFound(err) {
 			return false, nil
@@ -212,15 +212,15 @@ spec:
 		},
 		Spec: v1alpha1.KarydiaConfigSpec{
 			AutomountServiceAccountToken: "change-default",
-			SeccompProfile: "docker/default",
-			NetworkPolicy: "kube-system:karydia-default-network-policy",
+			SeccompProfile:               "docker/default",
+			NetworkPolicy:                "kube-system:karydia-default-network-policy",
 		},
 	}
 	_, err = f.KarydiaClientset.KarydiaV1alpha1().KarydiaConfigs().Create(crObject)
 	if err != nil {
 		return fmt.Errorf("failed to create: %v", crObject)
 	}
-	if err := wait.Poll(1 * time.Second, 20 * time.Second, func()(bool, error) {
+	if err := wait.Poll(1*time.Second, 20*time.Second, func() (bool, error) {
 		_, err := f.KarydiaClientset.KarydiaV1alpha1().KarydiaConfigs().Get(crObject.Name, metav1.GetOptions{})
 		if errors.IsNotFound(err) {
 			return false, nil


### PR DESCRIPTION
<!-- Thanks for sending a PR -->

### Description
Running `make test` now also checks for correct code formatting with `gofmt`. Unit-tests without format checks can be run with `make test-only` and format checks can be run standalone with `make fmt`.

Files in pkg, cli, and tests that were not conform with gofmt are formatted with this change.


### Checklist
Before submitting this PR, please make sure:
- [x] your code builds clean with `make`
- [x] your code lets succeed unit tests with `make test`
- [x] your code lets succeed integration tests
<!-- Please delete options that are not relevant -->
