### PR TITLE
Admission for pod security context

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -61,7 +61,6 @@ Karydia annotates the mutated resources with the at the time and context valid s
 | Pod |karydia.gardener.cloud/seccompProfile.internal | (`config` \| `namespace`) /(\<`profile-name`\>) |
 | Pod |karydia.gardener.cloud/podSecurityContext.internal | (`config` \| `namespace`) /(`nobody`) |
 | ServiceAccount | karydia.gardener.cloud/automountServiceAccountToken.internal | (`config` \| `namespace`) /(`change-default` \| `change-all`)|
-karydia.gardener.cloud/podSecurityContext
 
 ### karydia.gardener.cloud/automountServiceAccountToken
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -44,14 +44,15 @@ The features currently supported are:
 2. Secure-by-default Seccomp profiles
     - Applies the given Seccomp profile to all pods that do not explicitly specify another profile.
 3. Secure-by-default User and Group context for pods
-    - `nobody` set the user and group of all pods that do not explicitly specify another security context to id `65534`. 
+    - `nobody` set the user and group of all pods that do not explicitly specify another security context to id `65534`.
+    - `none` represents the fallback option and disables the feature.
 
 It is configured with the following namespace annotations:
 
 | Name | Type | Possible values |
 |---|---|---|
 |karydia.gardener.cloud/automountServiceAccountToken|string|`change-default` \| `change-all`|
-|karydia.gardener.cloud/podSecurityContext|string|`nobody`|
+|karydia.gardener.cloud/podSecurityContext|string|`nobody` \| `none`|
 |karydia.gardener.cloud/seccompProfile|string|Name of a valid profile, e.g. `runtime/default` or `localhost/my-profile`|
 
 Karydia annotates the mutated resources with the at the time and context valid security settings:
@@ -59,7 +60,7 @@ Karydia annotates the mutated resources with the at the time and context valid s
 | Resource | Annotation | Possible values |
 |---|---|---|
 | Pod |karydia.gardener.cloud/seccompProfile.internal | (`config` \| `namespace`) /(\<`profile-name`\>) |
-| Pod |karydia.gardener.cloud/podSecurityContext.internal | (`config` \| `namespace`) /(`nobody`) |
+| Pod |karydia.gardener.cloud/podSecurityContext.internal | (`config` \| `namespace`) /(`nobody` \| `none`) |
 | ServiceAccount | karydia.gardener.cloud/automountServiceAccountToken.internal | (`config` \| `namespace`) /(`change-default` \| `change-all`)|
 
 ### karydia.gardener.cloud/automountServiceAccountToken

--- a/docs/features.md
+++ b/docs/features.md
@@ -43,20 +43,25 @@ The features currently supported are:
     - `change-all` sets `automountServiceAccountToken` of all ServiceAccounts to `false` when undefined
 2. Secure-by-default Seccomp profiles
     - Applies the given Seccomp profile to all pods that do not explicitly specify another profile.
+3. Secure-by-default User and Group context for pods
+    - `nobody` set the user and group of all pods that do not explicitly specify another security context to id `65534`. 
 
 It is configured with the following namespace annotations:
 
 | Name | Type | Possible values |
 |---|---|---|
-|karydia.gardener.cloud/automountServiceAccountToken|string|`change-default` \| `change-all` 
+|karydia.gardener.cloud/automountServiceAccountToken|string|`change-default` \| `change-all`|
+|karydia.gardener.cloud/podSecurityContext|string|`nobody`|
 |karydia.gardener.cloud/seccompProfile|string|Name of a valid profile, e.g. `runtime/default` or `localhost/my-profile`|
 
 Karydia annotates the mutated resources with the at the time and context valid security settings:
 
 | Resource | Annotation | Possible values |
 |---|---|---|
-| Pod |karydia.gardener.cloud/seccompProfile.internal | (`config` \| `namespace`) /(\<`profile-name`\>)
+| Pod |karydia.gardener.cloud/seccompProfile.internal | (`config` \| `namespace`) /(\<`profile-name`\>) |
+| Pod |karydia.gardener.cloud/podSecurityContext.internal | (`config` \| `namespace`) /(`nobody`) |
 | ServiceAccount | karydia.gardener.cloud/automountServiceAccountToken.internal | (`config` \| `namespace`) /(`change-default` \| `change-all`)|
+karydia.gardener.cloud/podSecurityContext
 
 ### karydia.gardener.cloud/automountServiceAccountToken
 

--- a/install/charts/templates/config.yaml
+++ b/install/charts/templates/config.yaml
@@ -24,3 +24,4 @@ spec:
   automountServiceAccountToken: "{{ .Values.config.automountServiceAccountToken }}"
   seccompProfile: "{{ .Values.config.seccompProfile }}"
   networkPolicy: "{{ .Values.config.networkPolicy }}"
+  podSecurityContext: "{{ .Values.config.podSecurityContext }}"

--- a/install/charts/values.yaml
+++ b/install/charts/values.yaml
@@ -22,6 +22,7 @@ config:
   automountServiceAccountToken: "change-default"
   seccompProfile: "runtime/default"
   networkPolicy: "kube-system:karydia-default-network-policy"
+  podSecurityContext: "nobody"
   defaultNetworkPolicyExcludes: ""
 dev:
   active: false

--- a/pkg/admission/karydia/admission_pod.go
+++ b/pkg/admission/karydia/admission_pod.go
@@ -90,9 +90,14 @@ func validatePodSeccompProfile(pod corev1.Pod, setting Setting, validationErrors
 }
 
 func validatePodSecurityContext(pod corev1.Pod, setting Setting, validationErrors []string) []string {
-	if pod.Spec.SecurityContext == nil {
-		validationErrorMsg := fmt.Sprintf("security context must be defined")
-		validationErrors = append(validationErrors, validationErrorMsg)
+	if setting.value == "nobody" {
+		if pod.Spec.SecurityContext == nil {
+			validationErrorMsg := fmt.Sprintf("security context must be defined")
+			validationErrors = append(validationErrors, validationErrorMsg)
+		} else if pod.Spec.SecurityContext.RunAsUser == nil && pod.Spec.SecurityContext.RunAsGroup == nil {
+			validationErrorMsg := fmt.Sprintf("User or group in security context must be defined")
+			validationErrors = append(validationErrors, validationErrorMsg)
+		}
 	}
 	return validationErrors
 }

--- a/pkg/admission/karydia/admission_test.go
+++ b/pkg/admission/karydia/admission_test.go
@@ -38,7 +38,8 @@ func TestPodPlain(t *testing.T) {
 	namespace := &coreV1.Namespace{}
 	namespace.Name = "special"
 	namespace.Annotations = map[string]string{
-		"karydia.gardener.cloud/seccompProfile": "runtime/default",
+		"karydia.gardener.cloud/seccompProfile":     "runtime/default",
+		"karydia.gardener.cloud/podSecurityContext": "nobody",
 	}
 	kubeobjects = append(kubeobjects, namespace)
 
@@ -117,7 +118,8 @@ func TestPodCorrectSeccomp(t *testing.T) {
 	namespace := &coreV1.Namespace{}
 	namespace.Name = "special"
 	namespace.Annotations = map[string]string{
-		"karydia.gardener.cloud/seccompProfile": "runtime/default",
+		"karydia.gardener.cloud/seccompProfile":     "runtime/default",
+		"karydia.gardener.cloud/podSecurityContext": "nobody",
 	}
 	kubeobjects = append(kubeobjects, namespace)
 
@@ -185,6 +187,7 @@ func TestServiceAccountPlain(t *testing.T) {
 	namespace.Name = "special"
 	namespace.Annotations = map[string]string{
 		"karydia.gardener.cloud/automountServiceAccountToken": "change-all",
+		"karydia.gardener.cloud/podSecurityContext":           "nobody",
 	}
 	kubeobjects = append(kubeobjects, namespace)
 
@@ -256,6 +259,7 @@ func TestServiceAccountAutomountDefined(t *testing.T) {
 	namespace.Name = "special"
 	namespace.Annotations = map[string]string{
 		"karydia.gardener.cloud/automountServiceAccountToken": "change-all",
+		"karydia.gardener.cloud/podSecurityContext":           "nobody",
 	}
 	kubeobjects = append(kubeobjects, namespace)
 
@@ -330,6 +334,7 @@ func TestServiceAccountDefault(t *testing.T) {
 	namespace.Name = "special"
 	namespace.Annotations = map[string]string{
 		"karydia.gardener.cloud/automountServiceAccountToken": "change-default",
+		"karydia.gardener.cloud/podSecurityContext":           "nobody",
 	}
 	kubeobjects = append(kubeobjects, namespace)
 
@@ -507,6 +512,7 @@ func TestInvalidDecodeOfResources(t *testing.T) {
 	namespace.Name = "special"
 	namespace.Annotations = map[string]string{
 		"karydia.gardener.cloud/automountServiceAccountToken": "change-default",
+		"karydia.gardener.cloud/podSecurityContext":           "nobody",
 	}
 	kubeobjects = append(kubeobjects, namespace)
 

--- a/pkg/apis/karydia/v1alpha1/types.go
+++ b/pkg/apis/karydia/v1alpha1/types.go
@@ -42,6 +42,9 @@ type KarydiaConfigSpec struct {
 
 	// NetworkPolicy can be used to set a default network policy
 	NetworkPolicy string `json:"networkPolicy"`
+
+	// PodSecurityContext can be used to set a pod security context
+	PodSecurityContext string `json:"podSecurityContext"`
 }
 
 type KarydiaConfigStatus struct {

--- a/tests/e2e/admission_automount_token_test.go
+++ b/tests/e2e/admission_automount_token_test.go
@@ -42,64 +42,12 @@ type AutomountTokenTestCase struct {
 func TestAutomountServiceAccountToken(t *testing.T) {
 	testCases := []AutomountTokenTestCase{
 		{"default", nil, nil, nil, false},
-		{"default", nil, nil, &vTrue, true},
-		{"default", nil, nil, &vFalse, false},
-		{"default", nil, &vTrue, nil, true},
-		{"default", nil, &vTrue, &vTrue, true},
-		{"default", nil, &vTrue, &vFalse, false},
-		{"default", nil, &vFalse, nil, false},
-		{"default", nil, &vFalse, &vTrue, true},
-		{"default", nil, &vFalse, &vFalse, false},
-
 		{"default", &changeDefault, nil, nil, false},
-		{"default", &changeDefault, nil, &vTrue, true},
-		{"default", &changeDefault, nil, &vFalse, false},
-		{"default", &changeDefault, &vTrue, nil, true},
-		{"default", &changeDefault, &vTrue, &vTrue, true},
-		{"default", &changeDefault, &vTrue, &vFalse, false},
-		{"default", &changeDefault, &vFalse, nil, false},
-		{"default", &changeDefault, &vFalse, &vTrue, true},
-		{"default", &changeDefault, &vFalse, &vFalse, false},
-
 		{"default", &changeAll, nil, nil, false},
-		{"default", &changeAll, nil, &vTrue, true},
-		{"default", &changeAll, nil, &vFalse, false},
-		{"default", &changeAll, &vTrue, nil, true},
-		{"default", &changeAll, &vTrue, &vTrue, true},
-		{"default", &changeAll, &vTrue, &vFalse, false},
-		{"default", &changeAll, &vFalse, nil, false},
-		{"default", &changeAll, &vFalse, &vTrue, true},
-		{"default", &changeAll, &vFalse, &vFalse, false},
 
 		{"dedicated", nil, nil, nil, true},
-		{"dedicated", nil, nil, &vTrue, true},
-		{"dedicated", nil, nil, &vFalse, false},
-		{"dedicated", nil, &vTrue, nil, true},
-		{"dedicated", nil, &vTrue, &vTrue, true},
-		{"dedicated", nil, &vTrue, &vFalse, false},
-		{"dedicated", nil, &vFalse, nil, false},
-		{"dedicated", nil, &vFalse, &vTrue, true},
-		{"dedicated", nil, &vFalse, &vFalse, false},
-
 		{"dedicated", &changeDefault, nil, nil, true},
-		{"dedicated", &changeDefault, nil, &vTrue, true},
-		{"dedicated", &changeDefault, nil, &vFalse, false},
-		{"dedicated", &changeDefault, &vTrue, nil, true},
-		{"dedicated", &changeDefault, &vTrue, &vTrue, true},
-		{"dedicated", &changeDefault, &vTrue, &vFalse, false},
-		{"dedicated", &changeDefault, &vFalse, nil, false},
-		{"dedicated", &changeDefault, &vFalse, &vTrue, true},
-		{"dedicated", &changeDefault, &vFalse, &vFalse, false},
-
 		{"dedicated", &changeAll, nil, nil, false},
-		{"dedicated", &changeAll, nil, &vTrue, true},
-		{"dedicated", &changeAll, nil, &vFalse, false},
-		{"dedicated", &changeAll, &vTrue, nil, true},
-		{"dedicated", &changeAll, &vTrue, &vTrue, true},
-		{"dedicated", &changeAll, &vTrue, &vFalse, false},
-		{"dedicated", &changeAll, &vFalse, nil, false},
-		{"dedicated", &changeAll, &vFalse, &vTrue, true},
-		{"dedicated", &changeAll, &vFalse, &vFalse, false},
 	}
 
 	for _, tc := range testCases {
@@ -118,6 +66,7 @@ func TestAutomountServiceAccountToken(t *testing.T) {
 				   automatically created default service account */
 				annotation := map[string]string{
 					"karydia.gardener.cloud/automountServiceAccountToken": *tc.nsAnnotation,
+					"karydia.gardener.cloud/podSecurityContext":           "root",
 				}
 				namespace, err = f.CreateTestNamespaceWithAnnotation(annotation)
 				if err != nil {
@@ -165,8 +114,8 @@ func TestAutomountServiceAccountToken(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Name:  "nginx",
-							Image: "nginx",
+							Name:  "redis",
+							Image: "redis",
 						},
 					},
 				},
@@ -215,8 +164,8 @@ func TestAutomountServiceAccountTokenInDefaultNamespace(t *testing.T) {
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
 				{
-					Name:  "nginx",
-					Image: "nginx",
+					Name:  "redis",
+					Image: "redis",
 				},
 			},
 		},
@@ -248,6 +197,7 @@ func TestAutomountServiceAccountTokenEditServiceAccount(t *testing.T) {
 
 	annotation := map[string]string{
 		"karydia.gardener.cloud/automountServiceAccountToken": "change-all",
+		"karydia.gardener.cloud/podSecurityContext":           "root",
 	}
 	namespace, err = f.CreateTestNamespaceWithAnnotation(annotation)
 	if err != nil {
@@ -284,7 +234,9 @@ func TestAutomountServiceAccountTokenDefaultServiceAccountFromConfig(t *testing.
 	var namespace *corev1.Namespace
 	var err error
 
-	annotation := map[string]string{}
+	annotation := map[string]string{
+		"karydia.gardener.cloud/podSecurityContext": "root",
+	}
 	namespace, err = f.CreateTestNamespaceWithAnnotation(annotation)
 	if err != nil {
 		t.Fatalf("failed to create test namespace: %v", err)
@@ -343,7 +295,9 @@ func TestAutomountServiceAccountTokenDedicatedServiceAccountFromConfig(t *testin
 	var namespace *corev1.Namespace
 	var err error
 
-	annotation := map[string]string{}
+	annotation := map[string]string{
+		"karydia.gardener.cloud/podSecurityContext": "root",
+	}
 	namespace, err = f.CreateTestNamespaceWithAnnotation(annotation)
 	if err != nil {
 		t.Fatalf("failed to create test namespace: %v", err)

--- a/tests/e2e/admission_seccomp_test.go
+++ b/tests/e2e/admission_seccomp_test.go
@@ -26,7 +26,8 @@ import (
 
 func TestSeccompWithNamespaceAnnotationUndefinedProfile(t *testing.T) {
 	annotation := map[string]string{
-		"karydia.gardener.cloud/seccompProfile": "runtime/default",
+		"karydia.gardener.cloud/seccompProfile":     "runtime/default",
+		"karydia.gardener.cloud/podSecurityContext": "root",
 	}
 	namespace, err := f.CreateTestNamespaceWithAnnotation(annotation)
 	if err != nil {
@@ -67,7 +68,8 @@ func TestSeccompWithNamespaceAnnotationUndefinedProfile(t *testing.T) {
 
 func TestSeccompWithNamespaceAnnotationDefinedProfile(t *testing.T) {
 	annotation := map[string]string{
-		"karydia.gardener.cloud/seccompProfile": "docker/specific",
+		"karydia.gardener.cloud/seccompProfile":     "docker/specific",
+		"karydia.gardener.cloud/podSecurityContext": "root",
 	}
 	namespace, err := f.CreateTestNamespaceWithAnnotation(annotation)
 	if err != nil {
@@ -110,7 +112,9 @@ func TestSeccompWithNamespaceAnnotationDefinedProfile(t *testing.T) {
 }
 
 func TestSeccompWithoutNamespaceAnnotationUndefinedProfileFromConfig(t *testing.T) {
-	annotation := map[string]string{}
+	annotation := map[string]string{
+		"karydia.gardener.cloud/podSecurityContext": "root",
+	}
 	namespace, err := f.CreateTestNamespaceWithAnnotation(annotation)
 	if err != nil {
 		t.Fatalf("failed to create test namespace: %v", err)
@@ -150,7 +154,8 @@ func TestSeccompWithoutNamespaceAnnotationUndefinedProfileFromConfig(t *testing.
 
 func TestSeccompWithNamespaceAnnotationUndefinedProfileFromConfig(t *testing.T) {
 	annotation := map[string]string{
-		"karydia.gardener.cloud/seccompProfile": "unconfined",
+		"karydia.gardener.cloud/seccompProfile":     "unconfined",
+		"karydia.gardener.cloud/podSecurityContext": "root",
 	}
 	namespace, err := f.CreateTestNamespaceWithAnnotation(annotation)
 	if err != nil {
@@ -190,7 +195,9 @@ func TestSeccompWithNamespaceAnnotationUndefinedProfileFromConfig(t *testing.T) 
 }
 
 func TestSeccompWithoutNamespaceAnnotationDefinedProfile(t *testing.T) {
-	annotation := map[string]string{}
+	annotation := map[string]string{
+		"karydia.gardener.cloud/podSecurityContext": "root",
+	}
 	namespace, err := f.CreateTestNamespaceWithAnnotation(annotation)
 	if err != nil {
 		t.Fatalf("failed to create test namespace: %v", err)

--- a/tests/e2e/admission_security_context_test.go
+++ b/tests/e2e/admission_security_context_test.go
@@ -1,0 +1,166 @@
+// Copyright (C) 2019 SAP SE or an SAP affiliate company. All rights reserved.
+// This file is licensed under the Apache Software License, v. 2 except as
+// noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestSecurityContextWithNamespaceAnnotationUndefinedContext(t *testing.T) {
+	annotation := map[string]string{
+		"karydia.gardener.cloud/podSecurityContext": "nobody",
+	}
+	namespace, err := f.CreateTestNamespaceWithAnnotation(annotation)
+	if err != nil {
+		t.Fatalf("failed to create test namespace: %v", err)
+	}
+
+	ns := namespace.ObjectMeta.Name
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "karydia-e2e-test-pod",
+			Namespace: ns,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "redis",
+					Image: "redis",
+				},
+			},
+		},
+	}
+
+	createdPod, err := f.KubeClientset.CoreV1().Pods(ns).Create(pod)
+	if err != nil {
+		t.Fatalf("failed to create pod: %v", err)
+	}
+
+	secCtx := createdPod.Spec.SecurityContext
+	if secCtx == nil {
+		t.Fatalf("expected security context to be defined by admssion but is nil")
+	} else if *secCtx.RunAsUser != 65534 {
+		t.Fatalf("expected security context user id to be %v but is %v", 65534, *secCtx.RunAsUser)
+	} else if *secCtx.RunAsGroup != 65534 {
+		t.Fatalf("expected security context group id to be %v but is %v", 65534, *secCtx.RunAsGroup)
+	}
+
+	timeout := 2 * time.Minute
+	if err := f.WaitPodRunning(pod.ObjectMeta.Namespace, pod.ObjectMeta.Name, timeout); err != nil {
+		t.Fatalf("pod never reached state running")
+	}
+}
+
+func TestSecurityContextWithNamespaceAnnotationDefinedContext(t *testing.T) {
+	annotation := map[string]string{
+		"karydia.gardener.cloud/podSecurityContext": "nobody",
+	}
+	namespace, err := f.CreateTestNamespaceWithAnnotation(annotation)
+	if err != nil {
+		t.Fatalf("failed to create test namespace: %v", err)
+	}
+
+	ns := namespace.ObjectMeta.Name
+
+	var uid int64 = 1000
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "karydia-e2e-test-pod",
+			Namespace: ns,
+		},
+		Spec: corev1.PodSpec{
+			SecurityContext: &corev1.PodSecurityContext{
+				RunAsUser: &uid,
+			},
+			Containers: []corev1.Container{
+				{
+					Name:  "redis",
+					Image: "redis",
+				},
+			},
+		},
+	}
+
+	createdPod, err := f.KubeClientset.CoreV1().Pods(ns).Create(pod)
+	if err != nil {
+		t.Fatalf("failed to create pod: %v", err)
+	}
+
+	secCtx := createdPod.Spec.SecurityContext
+	if secCtx == nil {
+		t.Fatalf("expected security context to be defined by pod definition but is nil")
+	} else if *secCtx.RunAsUser != 1000 {
+		t.Fatalf("expected security context user id to be %v but is %v", 1000, *secCtx.RunAsUser)
+	} else if secCtx.RunAsGroup != nil {
+		t.Fatalf("expected security context group id to be %v but is %v", "nil", *secCtx.RunAsGroup)
+	}
+
+	timeout := 2 * time.Minute
+	if err := f.WaitPodRunning(pod.ObjectMeta.Namespace, pod.ObjectMeta.Name, timeout); err != nil {
+		t.Fatalf("pod never reached state running")
+	}
+}
+
+func TestSecurityContextWithoutNamespaceAnnotationUndefinedContextFromConfig(t *testing.T) {
+	annotation := map[string]string{}
+	namespace, err := f.CreateTestNamespaceWithAnnotation(annotation)
+	if err != nil {
+		t.Fatalf("failed to create test namespace: %v", err)
+	}
+
+	ns := namespace.ObjectMeta.Name
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "karydia-e2e-test-pod",
+			Namespace: ns,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "redis",
+					Image: "redis",
+				},
+			},
+		},
+	}
+
+	createdPod, err := f.KubeClientset.CoreV1().Pods(ns).Create(pod)
+	if err != nil {
+		t.Fatalf("failed to create pod: %v", err)
+	}
+
+	secCtx := createdPod.Spec.SecurityContext
+	if secCtx == nil {
+		t.Fatalf("expected security context to be defined by admssion but is nil")
+	} else if *secCtx.RunAsUser != 65534 {
+		t.Fatalf("expected security context user id to be %v but is %v", 65534, *secCtx.RunAsUser)
+	} else if *secCtx.RunAsGroup != 65534 {
+		t.Fatalf("expected security context group id to be %v but is %v", 65534, *secCtx.RunAsGroup)
+	}
+
+	timeout := 2 * time.Minute
+	if err := f.WaitPodRunning(pod.ObjectMeta.Namespace, pod.ObjectMeta.Name, timeout); err != nil {
+		t.Fatalf("pod never reached state running")
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a PR -->

### Description
A new security setting `karydia.gardener.cloud/podSecurityContext` is introduced to set the SecurityContext of pods secure-by-default. When `nobody` is configured for this setting, the user and group id of a pod's containers is set to id `65534` resp. `nobody`. This is accomplished by mutating the SecurityContext of each pod that does not explicitly define a SecurityContext.

### Checklist
Before submitting this PR, please make sure:
- [x] you have added unit tests
- [x] you have added integration tests
- [x] your code builds clean with `make`
- [x] your code lets succeed unit tests with `make test`
- [x] your code lets succeed integration tests
- [x] you have documented new or changed features
<!-- Please delete options that are not relevant -->
