### PR TITLE
Karydia Default Network Policy Security extensions

### DIFF
--- a/docs/demos/seccomp.md
+++ b/docs/demos/seccomp.md
@@ -58,6 +58,3 @@ unshare --user whoami
 
 => Operation not permitted
 ```
-
-# Overview of "docker/default" seccomp
-An overview of the not permitted sycalls can be found on the docker [website](https://docs.docker.com/engine/security/seccomp/).

--- a/docs/features.md
+++ b/docs/features.md
@@ -33,6 +33,12 @@ not running will not be updated when karydia starts.
 
 The network policy is expected to be found under `.data.policy` in the configmap.
 
+The current network policy called `karydia-default-network-policy` has three security measures:
+2. block access to Meta Data Services (AWS, GCP, Azure, Ali Cloud)
+2. block access to Meta Data Services (AWS, GCP, Ali Cloud)
+
+Note: The network policy is still quite open. It uses a blacklisting approach and does not block Internet access (Egress) which is necessary for the protection of malware. The `karydia-network-policy-level2` follows soon: It uses a whitelisting approach and blocks Egress.
+
 ## Karydia Admission
 
 Karydia Admission (`--enable-karydia-admission`) offers features with the goal of a secure-by-default cluster setup. You can enable/disable and configure this feature in the `install/charts/values.yaml` file.

--- a/docs/features.md
+++ b/docs/features.md
@@ -43,19 +43,24 @@ The features currently supported are:
     - `change-all` sets `automountServiceAccountToken` of all ServiceAccounts to `false` when undefined
 2. Secure-by-default Seccomp profiles
     - Applies the given Seccomp profile to all pods that do not explicitly specify another profile.
+3. Secure-by-default User and Group context for pods
+    - `nobody` set the user and group of all pods that do not explicitly specify another security context to id `65534`.
+    - `none` represents the fallback option and disables the feature.
 
 It is configured with the following namespace annotations:
 
 | Name | Type | Possible values |
 |---|---|---|
-|karydia.gardener.cloud/automountServiceAccountToken|string|`change-default` \| `change-all` 
+|karydia.gardener.cloud/automountServiceAccountToken|string|`change-default` \| `change-all`|
+|karydia.gardener.cloud/podSecurityContext|string|`nobody` \| `none`|
 |karydia.gardener.cloud/seccompProfile|string|Name of a valid profile, e.g. `runtime/default` or `localhost/my-profile`|
 
 Karydia annotates the mutated resources with the at the time and context valid security settings:
 
 | Resource | Annotation | Possible values |
 |---|---|---|
-| Pod |karydia.gardener.cloud/seccompProfile.internal | (`config` \| `namespace`) /(\<`profile-name`\>)
+| Pod |karydia.gardener.cloud/seccompProfile.internal | (`config` \| `namespace`) /(\<`profile-name`\>) |
+| Pod |karydia.gardener.cloud/podSecurityContext.internal | (`config` \| `namespace`) /(`nobody` \| `none`) |
 | ServiceAccount | karydia.gardener.cloud/automountServiceAccountToken.internal | (`config` \| `namespace`) /(`change-default` \| `change-all`)|
 
 ### karydia.gardener.cloud/automountServiceAccountToken

--- a/install/charts/templates/config.yaml
+++ b/install/charts/templates/config.yaml
@@ -24,3 +24,4 @@ spec:
   automountServiceAccountToken: "{{ .Values.config.automountServiceAccountToken }}"
   seccompProfile: "{{ .Values.config.seccompProfile }}"
   networkPolicy: "{{ .Values.config.networkPolicy }}"
+  podSecurityContext: "{{ .Values.config.podSecurityContext }}"

--- a/install/charts/templates/configmap.yaml
+++ b/install/charts/templates/configmap.yaml
@@ -28,5 +28,5 @@ data:
     {{- include "create-karydia-certificate.sh.tpl" . | indent 4}}
   create-karydia-tls-secret.sh: |-
     {{- include "create-karydia-tls-secret.sh.tpl" . | indent 4}}
-  example-default-network-policy.sh: |-
-    {{- include "example-default-network-policy.sh.tpl" . | indent 4}}
+  karydia-default-network-policy.sh: |-
+    {{- include "karydia-default-network-policy.sh.tpl" . | indent 4}}

--- a/install/charts/templates/deployment.yaml
+++ b/install/charts/templates/deployment.yaml
@@ -84,7 +84,7 @@ spec:
       initContainers:
       - name: pre-install-{{ .Values.metadata.name }}
         image: lachlanevenson/k8s-kubectl
-        command: ['sh', '-c', 'apk add --update --no-cache openssl && sh /tmp/create-karydia-certificate.sh && sh /tmp/create-karydia-tls-secret.sh && sh /tmp/example-default-network-policy.sh']
+        command: ['sh', '-c', 'apk add --update --no-cache openssl && sh /tmp/create-karydia-certificate.sh && sh /tmp/create-karydia-tls-secret.sh && sh /tmp/karydia-default-network-policy.sh']
         volumeMounts:
         - name: workdir
           mountPath: "/tmp"

--- a/install/charts/templates/karydia-default-network-policy.sh.tpl
+++ b/install/charts/templates/karydia-default-network-policy.sh.tpl
@@ -1,4 +1,4 @@
-{{ define "example-default-network-policy.sh.tpl" }}
+{{ define "karydia-default-network-policy.sh.tpl" }}
 #!/bin/bash
 
 # Copyright (C) 2019 SAP SE or an SAP affiliate company. All rights reserved.
@@ -31,6 +31,14 @@ spec:
   podSelector: {}
   policyTypes:
   - Egress
+  egress:
+  - to:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+        except:
+        - 10.250.0.0/16      # host network IP for AWS
+        - 169.254.169.254/16 # AWS = Google = Azure
+        - 100.100.0.0/16     # Ali Cloud Meta Data Services
 EOF
 )
 

--- a/install/charts/values.yaml
+++ b/install/charts/values.yaml
@@ -20,7 +20,7 @@ features:
 config:
   name: "karydia-config"
   automountServiceAccountToken: "change-default"
-  seccompProfile: "docker/default"
+  seccompProfile: "runtime/default"
   networkPolicy: "kube-system:karydia-default-network-policy"
   defaultNetworkPolicyExcludes: ""
 dev:

--- a/install/charts/values.yaml
+++ b/install/charts/values.yaml
@@ -22,6 +22,7 @@ config:
   automountServiceAccountToken: "change-default"
   seccompProfile: "runtime/default"
   networkPolicy: "kube-system:karydia-default-network-policy"
+  podSecurityContext: "nobody"
   defaultNetworkPolicyExcludes: ""
 dev:
   active: false

--- a/pkg/admission/karydia/admission_test.go
+++ b/pkg/admission/karydia/admission_test.go
@@ -32,13 +32,93 @@ import (
 )
 
 /* Admission with ´mutating and validating webhook */
-func TestPodPlain(t *testing.T) {
+func TestPodPlainSeccomp(t *testing.T) {
 	var kubeobjects []runtime.Object
 
 	namespace := &coreV1.Namespace{}
 	namespace.Name = "special"
 	namespace.Annotations = map[string]string{
-		"karydia.gardener.cloud/seccompProfile": "runtime/default",
+		"karydia.gardener.cloud/seccompProfile":     "runtime/default",
+		"karydia.gardener.cloud/podSecurityContext": "nobody",
+	}
+	kubeobjects = append(kubeobjects, namespace)
+
+	kubeclient := k8sfake.NewSimpleClientset(kubeobjects...)
+
+	karydiaAdmission, err := New(&Config{
+		KubeClientset: kubeclient,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to load karydia admission: %v\n", err)
+		os.Exit(1)
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "karydia-e2e-test-pod",
+			Namespace: "special",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "nginx",
+					Image: "nginx",
+				},
+			},
+		},
+	}
+	rawPod, _ := json.Marshal(pod)
+
+	ar := v1beta1.AdmissionReview{
+		Request: &v1beta1.AdmissionRequest{
+			Operation: "CREATE",
+			Namespace: "special",
+			Kind:      metav1.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"},
+			Object: runtime.RawExtension{
+				Raw: rawPod,
+			},
+		},
+	}
+
+	mutationResponse := karydiaAdmission.Admit(ar, true)
+	if !mutationResponse.Allowed {
+		t.Errorf("expected mutation response to be true but is %v", mutationResponse.Allowed)
+	}
+
+	var patches []patchOperation
+	err = json.Unmarshal(mutationResponse.Patch, &patches)
+	if len(patches) != 4 {
+		t.Errorf("expected number of patches to be 4 but is %v", len(patches))
+	}
+
+	t.Log(patches)
+
+	mutatedPod, err := patchPodRaw(*pod, mutationResponse.Patch)
+	if err != nil {
+		t.Errorf("failed to apply patches: %+v", err)
+	}
+
+	validationResponse := karydiaAdmission.Admit(ar, false)
+	if validationResponse.Allowed {
+		t.Errorf("expected validation response to be false but is %v", validationResponse.Allowed)
+	}
+
+	ar.Request.Object.Raw, _ = json.Marshal(mutatedPod)
+
+	validationResponse = karydiaAdmission.Admit(ar, false)
+	if !validationResponse.Allowed {
+		t.Errorf("expected validation response to be true but is %v", validationResponse.Allowed)
+	}
+
+}
+
+func TestPodPlainSecContext(t *testing.T) {
+	var kubeobjects []runtime.Object
+
+	namespace := &coreV1.Namespace{}
+	namespace.Name = "special"
+	namespace.Annotations = map[string]string{
+		"karydia.gardener.cloud/podSecurityContext": "nobody",
 	}
 	kubeobjects = append(kubeobjects, namespace)
 
@@ -111,13 +191,97 @@ func TestPodPlain(t *testing.T) {
 
 }
 
+func TestPodDefinedSecContext(t *testing.T) {
+	var kubeobjects []runtime.Object
+
+	namespace := &coreV1.Namespace{}
+	namespace.Name = "special"
+	namespace.Annotations = map[string]string{
+		"karydia.gardener.cloud/podSecurityContext": "nobody",
+	}
+	kubeobjects = append(kubeobjects, namespace)
+
+	kubeclient := k8sfake.NewSimpleClientset(kubeobjects...)
+
+	karydiaAdmission, err := New(&Config{
+		KubeClientset: kubeclient,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to load karydia admission: %v\n", err)
+		os.Exit(1)
+	}
+
+	var uid int64 = 1000
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "karydia-e2e-test-pod",
+			Namespace: "special",
+		},
+		Spec: corev1.PodSpec{
+			SecurityContext: &corev1.PodSecurityContext{
+				RunAsUser: &uid,
+			},
+			Containers: []corev1.Container{
+				{
+					Name:  "nginx",
+					Image: "nginx",
+				},
+			},
+		},
+	}
+	rawPod, _ := json.Marshal(pod)
+
+	ar := v1beta1.AdmissionReview{
+		Request: &v1beta1.AdmissionRequest{
+			Operation: "CREATE",
+			Namespace: "special",
+			Kind:      metav1.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"},
+			Object: runtime.RawExtension{
+				Raw: rawPod,
+			},
+		},
+	}
+
+	mutationResponse := karydiaAdmission.Admit(ar, true)
+	if !mutationResponse.Allowed {
+		t.Errorf("expected mutation response to be true but is %v", mutationResponse.Allowed)
+	}
+
+	var patches []patchOperation
+	err = json.Unmarshal(mutationResponse.Patch, &patches)
+	if len(patches) != 0 {
+		t.Errorf("expected number of patches to be 0 but is %v", len(patches))
+	}
+
+	t.Log(patches)
+
+	mutatedPod, err := patchPodRaw(*pod, mutationResponse.Patch)
+	if err != nil {
+		t.Errorf("failed to apply patches: %+v", err)
+	}
+
+	validationResponse := karydiaAdmission.Admit(ar, false)
+	if !validationResponse.Allowed {
+		t.Errorf("expected validation response to be true but is %v", validationResponse.Allowed)
+	}
+
+	ar.Request.Object.Raw, _ = json.Marshal(mutatedPod)
+
+	validationResponse = karydiaAdmission.Admit(ar, false)
+	if !validationResponse.Allowed {
+		t.Errorf("expected validation response to be true but is %v", validationResponse.Allowed)
+	}
+
+}
+
 func TestPodCorrectSeccomp(t *testing.T) {
 	var kubeobjects []runtime.Object
 
 	namespace := &coreV1.Namespace{}
 	namespace.Name = "special"
 	namespace.Annotations = map[string]string{
-		"karydia.gardener.cloud/seccompProfile": "runtime/default",
+		"karydia.gardener.cloud/seccompProfile": "docker/default",
 	}
 	kubeobjects = append(kubeobjects, namespace)
 

--- a/pkg/admission/karydia/admission_test.go
+++ b/pkg/admission/karydia/admission_test.go
@@ -38,7 +38,7 @@ func TestPodPlain(t *testing.T) {
 	namespace := &coreV1.Namespace{}
 	namespace.Name = "special"
 	namespace.Annotations = map[string]string{
-		"karydia.gardener.cloud/seccompProfile": "docker/default",
+		"karydia.gardener.cloud/seccompProfile": "runtime/default",
 	}
 	kubeobjects = append(kubeobjects, namespace)
 
@@ -117,7 +117,7 @@ func TestPodCorrectSeccomp(t *testing.T) {
 	namespace := &coreV1.Namespace{}
 	namespace.Name = "special"
 	namespace.Annotations = map[string]string{
-		"karydia.gardener.cloud/seccompProfile": "docker/default",
+		"karydia.gardener.cloud/seccompProfile": "runtime/default",
 	}
 	kubeobjects = append(kubeobjects, namespace)
 
@@ -136,7 +136,7 @@ func TestPodCorrectSeccomp(t *testing.T) {
 			Name:      "karydia-e2e-test-pod",
 			Namespace: "special",
 			Annotations: map[string]string{
-				"seccomp.security.alpha.kubernetes.io/pod": "docker/default",
+				"seccomp.security.alpha.kubernetes.io/pod": "runtime/default",
 			},
 		},
 		Spec: corev1.PodSpec{

--- a/pkg/apis/karydia/v1alpha1/types.go
+++ b/pkg/apis/karydia/v1alpha1/types.go
@@ -42,6 +42,9 @@ type KarydiaConfigSpec struct {
 
 	// NetworkPolicy can be used to set a default network policy
 	NetworkPolicy string `json:"networkPolicy"`
+
+	// PodSecurityContext can be used to set a pod security context
+	PodSecurityContext string `json:"podSecurityContext"`
 }
 
 type KarydiaConfigStatus struct {

--- a/tests/e2e/admission_automount_token_test.go
+++ b/tests/e2e/admission_automount_token_test.go
@@ -42,64 +42,12 @@ type AutomountTokenTestCase struct {
 func TestAutomountServiceAccountToken(t *testing.T) {
 	testCases := []AutomountTokenTestCase{
 		{"default", nil, nil, nil, false},
-		{"default", nil, nil, &vTrue, true},
-		{"default", nil, nil, &vFalse, false},
-		{"default", nil, &vTrue, nil, true},
-		{"default", nil, &vTrue, &vTrue, true},
-		{"default", nil, &vTrue, &vFalse, false},
-		{"default", nil, &vFalse, nil, false},
-		{"default", nil, &vFalse, &vTrue, true},
-		{"default", nil, &vFalse, &vFalse, false},
-
 		{"default", &changeDefault, nil, nil, false},
-		{"default", &changeDefault, nil, &vTrue, true},
-		{"default", &changeDefault, nil, &vFalse, false},
-		{"default", &changeDefault, &vTrue, nil, true},
-		{"default", &changeDefault, &vTrue, &vTrue, true},
-		{"default", &changeDefault, &vTrue, &vFalse, false},
-		{"default", &changeDefault, &vFalse, nil, false},
-		{"default", &changeDefault, &vFalse, &vTrue, true},
-		{"default", &changeDefault, &vFalse, &vFalse, false},
-
 		{"default", &changeAll, nil, nil, false},
-		{"default", &changeAll, nil, &vTrue, true},
-		{"default", &changeAll, nil, &vFalse, false},
-		{"default", &changeAll, &vTrue, nil, true},
-		{"default", &changeAll, &vTrue, &vTrue, true},
-		{"default", &changeAll, &vTrue, &vFalse, false},
-		{"default", &changeAll, &vFalse, nil, false},
-		{"default", &changeAll, &vFalse, &vTrue, true},
-		{"default", &changeAll, &vFalse, &vFalse, false},
 
 		{"dedicated", nil, nil, nil, true},
-		{"dedicated", nil, nil, &vTrue, true},
-		{"dedicated", nil, nil, &vFalse, false},
-		{"dedicated", nil, &vTrue, nil, true},
-		{"dedicated", nil, &vTrue, &vTrue, true},
-		{"dedicated", nil, &vTrue, &vFalse, false},
-		{"dedicated", nil, &vFalse, nil, false},
-		{"dedicated", nil, &vFalse, &vTrue, true},
-		{"dedicated", nil, &vFalse, &vFalse, false},
-
 		{"dedicated", &changeDefault, nil, nil, true},
-		{"dedicated", &changeDefault, nil, &vTrue, true},
-		{"dedicated", &changeDefault, nil, &vFalse, false},
-		{"dedicated", &changeDefault, &vTrue, nil, true},
-		{"dedicated", &changeDefault, &vTrue, &vTrue, true},
-		{"dedicated", &changeDefault, &vTrue, &vFalse, false},
-		{"dedicated", &changeDefault, &vFalse, nil, false},
-		{"dedicated", &changeDefault, &vFalse, &vTrue, true},
-		{"dedicated", &changeDefault, &vFalse, &vFalse, false},
-
 		{"dedicated", &changeAll, nil, nil, false},
-		{"dedicated", &changeAll, nil, &vTrue, true},
-		{"dedicated", &changeAll, nil, &vFalse, false},
-		{"dedicated", &changeAll, &vTrue, nil, true},
-		{"dedicated", &changeAll, &vTrue, &vTrue, true},
-		{"dedicated", &changeAll, &vTrue, &vFalse, false},
-		{"dedicated", &changeAll, &vFalse, nil, false},
-		{"dedicated", &changeAll, &vFalse, &vTrue, true},
-		{"dedicated", &changeAll, &vFalse, &vFalse, false},
 	}
 
 	for _, tc := range testCases {
@@ -118,6 +66,7 @@ func TestAutomountServiceAccountToken(t *testing.T) {
 				   automatically created default service account */
 				annotation := map[string]string{
 					"karydia.gardener.cloud/automountServiceAccountToken": *tc.nsAnnotation,
+					"karydia.gardener.cloud/podSecurityContext":           "root",
 				}
 				namespace, err = f.CreateTestNamespaceWithAnnotation(annotation)
 				if err != nil {
@@ -165,8 +114,8 @@ func TestAutomountServiceAccountToken(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Name:  "nginx",
-							Image: "nginx",
+							Name:  "redis",
+							Image: "redis",
 						},
 					},
 				},
@@ -215,8 +164,8 @@ func TestAutomountServiceAccountTokenInDefaultNamespace(t *testing.T) {
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
 				{
-					Name:  "nginx",
-					Image: "nginx",
+					Name:  "redis",
+					Image: "redis",
 				},
 			},
 		},
@@ -248,6 +197,7 @@ func TestAutomountServiceAccountTokenEditServiceAccount(t *testing.T) {
 
 	annotation := map[string]string{
 		"karydia.gardener.cloud/automountServiceAccountToken": "change-all",
+		"karydia.gardener.cloud/podSecurityContext":           "root",
 	}
 	namespace, err = f.CreateTestNamespaceWithAnnotation(annotation)
 	if err != nil {
@@ -284,7 +234,9 @@ func TestAutomountServiceAccountTokenDefaultServiceAccountFromConfig(t *testing.
 	var namespace *corev1.Namespace
 	var err error
 
-	annotation := map[string]string{}
+	annotation := map[string]string{
+		"karydia.gardener.cloud/podSecurityContext": "root",
+	}
 	namespace, err = f.CreateTestNamespaceWithAnnotation(annotation)
 	if err != nil {
 		t.Fatalf("failed to create test namespace: %v", err)
@@ -343,7 +295,9 @@ func TestAutomountServiceAccountTokenDedicatedServiceAccountFromConfig(t *testin
 	var namespace *corev1.Namespace
 	var err error
 
-	annotation := map[string]string{}
+	annotation := map[string]string{
+		"karydia.gardener.cloud/podSecurityContext": "root",
+	}
 	namespace, err = f.CreateTestNamespaceWithAnnotation(annotation)
 	if err != nil {
 		t.Fatalf("failed to create test namespace: %v", err)

--- a/tests/e2e/admission_seccomp_test.go
+++ b/tests/e2e/admission_seccomp_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestSeccompWithNamespaceAnnotationUndefinedProfile(t *testing.T) {
 	annotation := map[string]string{
-		"karydia.gardener.cloud/seccompProfile": "docker/default",
+		"karydia.gardener.cloud/seccompProfile": "runtime/default",
 	}
 	namespace, err := f.CreateTestNamespaceWithAnnotation(annotation)
 	if err != nil {
@@ -55,8 +55,8 @@ func TestSeccompWithNamespaceAnnotationUndefinedProfile(t *testing.T) {
 		t.Fatalf("failed to create pod: %v", err)
 	}
 
-	if profile := createdPod.ObjectMeta.Annotations["seccomp.security.alpha.kubernetes.io/pod"]; profile != "docker/default" {
-		t.Fatalf("expected seccomp profile to be %v but is %v", "docker/default", profile)
+	if profile := createdPod.ObjectMeta.Annotations["seccomp.security.alpha.kubernetes.io/pod"]; profile != "runtime/default" {
+		t.Fatalf("expected seccomp profile to be %v but is %v", "runtime/default", profile)
 	}
 
 	timeout := 2 * time.Minute
@@ -81,7 +81,7 @@ func TestSeccompWithNamespaceAnnotationDefinedProfile(t *testing.T) {
 			Name:      "karydia-e2e-test-pod",
 			Namespace: ns,
 			Annotations: map[string]string{
-				"seccomp.security.alpha.kubernetes.io/pod": "docker/default",
+				"seccomp.security.alpha.kubernetes.io/pod": "runtime/default",
 			},
 		},
 		Spec: corev1.PodSpec{
@@ -99,8 +99,8 @@ func TestSeccompWithNamespaceAnnotationDefinedProfile(t *testing.T) {
 		t.Fatalf("failed to create pod: %v", err)
 	}
 
-	if profile := createdPod.ObjectMeta.Annotations["seccomp.security.alpha.kubernetes.io/pod"]; profile != "docker/default" {
-		t.Fatalf("expected seccomp profile to be %v but is %v", "docker/default", profile)
+	if profile := createdPod.ObjectMeta.Annotations["seccomp.security.alpha.kubernetes.io/pod"]; profile != "runtime/default" {
+		t.Fatalf("expected seccomp profile to be %v but is %v", "runtime/default", profile)
 	}
 
 	timeout := 2 * time.Minute
@@ -138,8 +138,8 @@ func TestSeccompWithoutNamespaceAnnotationUndefinedProfileFromConfig(t *testing.
 		t.Fatalf("failed to create pod: %v", err)
 	}
 
-	if profile := createdPod.ObjectMeta.Annotations["seccomp.security.alpha.kubernetes.io/pod"]; profile != "docker/default" {
-		t.Fatalf("expected seccomp profile to be %v but is %v", "docker/default", profile)
+	if profile := createdPod.ObjectMeta.Annotations["seccomp.security.alpha.kubernetes.io/pod"]; profile != "runtime/default" {
+		t.Fatalf("expected seccomp profile to be %v but is %v", "runtime/default", profile)
 	}
 
 	timeout := 2 * time.Minute
@@ -203,7 +203,7 @@ func TestSeccompWithoutNamespaceAnnotationDefinedProfile(t *testing.T) {
 			Name:      "karydia-e2e-test-pod",
 			Namespace: ns,
 			Annotations: map[string]string{
-				"seccomp.security.alpha.kubernetes.io/pod": "docker/default",
+				"seccomp.security.alpha.kubernetes.io/pod": "runtime/default",
 			},
 		},
 		Spec: corev1.PodSpec{
@@ -221,8 +221,8 @@ func TestSeccompWithoutNamespaceAnnotationDefinedProfile(t *testing.T) {
 		t.Fatalf("failed to create pod: %v", err)
 	}
 
-	if profile := createdPod.ObjectMeta.Annotations["seccomp.security.alpha.kubernetes.io/pod"]; profile != "docker/default" {
-		t.Fatalf("expected seccomp profile to be %v but is %v", "docker/default", profile)
+	if profile := createdPod.ObjectMeta.Annotations["seccomp.security.alpha.kubernetes.io/pod"]; profile != "runtime/default" {
+		t.Fatalf("expected seccomp profile to be %v but is %v", "runtime/default", profile)
 	}
 
 	timeout := 2 * time.Minute

--- a/tests/e2e/admission_seccomp_test.go
+++ b/tests/e2e/admission_seccomp_test.go
@@ -26,7 +26,8 @@ import (
 
 func TestSeccompWithNamespaceAnnotationUndefinedProfile(t *testing.T) {
 	annotation := map[string]string{
-		"karydia.gardener.cloud/seccompProfile": "runtime/default",
+		"karydia.gardener.cloud/seccompProfile":     "runtime/default",
+		"karydia.gardener.cloud/podSecurityContext": "root",
 	}
 	namespace, err := f.CreateTestNamespaceWithAnnotation(annotation)
 	if err != nil {
@@ -67,7 +68,8 @@ func TestSeccompWithNamespaceAnnotationUndefinedProfile(t *testing.T) {
 
 func TestSeccompWithNamespaceAnnotationDefinedProfile(t *testing.T) {
 	annotation := map[string]string{
-		"karydia.gardener.cloud/seccompProfile": "docker/specific",
+		"karydia.gardener.cloud/seccompProfile":     "docker/specific",
+		"karydia.gardener.cloud/podSecurityContext": "root",
 	}
 	namespace, err := f.CreateTestNamespaceWithAnnotation(annotation)
 	if err != nil {
@@ -110,7 +112,9 @@ func TestSeccompWithNamespaceAnnotationDefinedProfile(t *testing.T) {
 }
 
 func TestSeccompWithoutNamespaceAnnotationUndefinedProfileFromConfig(t *testing.T) {
-	annotation := map[string]string{}
+	annotation := map[string]string{
+		"karydia.gardener.cloud/podSecurityContext": "root",
+	}
 	namespace, err := f.CreateTestNamespaceWithAnnotation(annotation)
 	if err != nil {
 		t.Fatalf("failed to create test namespace: %v", err)
@@ -150,7 +154,8 @@ func TestSeccompWithoutNamespaceAnnotationUndefinedProfileFromConfig(t *testing.
 
 func TestSeccompWithNamespaceAnnotationUndefinedProfileFromConfig(t *testing.T) {
 	annotation := map[string]string{
-		"karydia.gardener.cloud/seccompProfile": "unconfined",
+		"karydia.gardener.cloud/seccompProfile":     "unconfined",
+		"karydia.gardener.cloud/podSecurityContext": "root",
 	}
 	namespace, err := f.CreateTestNamespaceWithAnnotation(annotation)
 	if err != nil {
@@ -190,7 +195,9 @@ func TestSeccompWithNamespaceAnnotationUndefinedProfileFromConfig(t *testing.T) 
 }
 
 func TestSeccompWithoutNamespaceAnnotationDefinedProfile(t *testing.T) {
-	annotation := map[string]string{}
+	annotation := map[string]string{
+		"karydia.gardener.cloud/podSecurityContext": "root",
+	}
 	namespace, err := f.CreateTestNamespaceWithAnnotation(annotation)
 	if err != nil {
 		t.Fatalf("failed to create test namespace: %v", err)

--- a/tests/e2e/admission_security_context_test.go
+++ b/tests/e2e/admission_security_context_test.go
@@ -1,0 +1,166 @@
+// Copyright (C) 2019 SAP SE or an SAP affiliate company. All rights reserved.
+// This file is licensed under the Apache Software License, v. 2 except as
+// noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestSecurityContextWithNamespaceAnnotationUndefinedContext(t *testing.T) {
+	annotation := map[string]string{
+		"karydia.gardener.cloud/podSecurityContext": "nobody",
+	}
+	namespace, err := f.CreateTestNamespaceWithAnnotation(annotation)
+	if err != nil {
+		t.Fatalf("failed to create test namespace: %v", err)
+	}
+
+	ns := namespace.ObjectMeta.Name
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "karydia-e2e-test-pod",
+			Namespace: ns,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "redis",
+					Image: "redis",
+				},
+			},
+		},
+	}
+
+	createdPod, err := f.KubeClientset.CoreV1().Pods(ns).Create(pod)
+	if err != nil {
+		t.Fatalf("failed to create pod: %v", err)
+	}
+
+	secCtx := createdPod.Spec.SecurityContext
+	if secCtx == nil {
+		t.Fatalf("expected security context to be defined by admssion but is nil")
+	} else if *secCtx.RunAsUser != 65534 {
+		t.Fatalf("expected security context user id to be %v but is %v", 65534, *secCtx.RunAsUser)
+	} else if *secCtx.RunAsGroup != 65534 {
+		t.Fatalf("expected security context group id to be %v but is %v", 65534, *secCtx.RunAsGroup)
+	}
+
+	timeout := 2 * time.Minute
+	if err := f.WaitPodRunning(pod.ObjectMeta.Namespace, pod.ObjectMeta.Name, timeout); err != nil {
+		t.Fatalf("pod never reached state running")
+	}
+}
+
+func TestSecurityContextWithNamespaceAnnotationDefinedContext(t *testing.T) {
+	annotation := map[string]string{
+		"karydia.gardener.cloud/podSecurityContext": "nobody",
+	}
+	namespace, err := f.CreateTestNamespaceWithAnnotation(annotation)
+	if err != nil {
+		t.Fatalf("failed to create test namespace: %v", err)
+	}
+
+	ns := namespace.ObjectMeta.Name
+
+	var uid int64 = 1000
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "karydia-e2e-test-pod",
+			Namespace: ns,
+		},
+		Spec: corev1.PodSpec{
+			SecurityContext: &corev1.PodSecurityContext{
+				RunAsUser: &uid,
+			},
+			Containers: []corev1.Container{
+				{
+					Name:  "redis",
+					Image: "redis",
+				},
+			},
+		},
+	}
+
+	createdPod, err := f.KubeClientset.CoreV1().Pods(ns).Create(pod)
+	if err != nil {
+		t.Fatalf("failed to create pod: %v", err)
+	}
+
+	secCtx := createdPod.Spec.SecurityContext
+	if secCtx == nil {
+		t.Fatalf("expected security context to be defined by pod definition but is nil")
+	} else if *secCtx.RunAsUser != 1000 {
+		t.Fatalf("expected security context user id to be %v but is %v", 1000, *secCtx.RunAsUser)
+	} else if secCtx.RunAsGroup != nil {
+		t.Fatalf("expected security context group id to be %v but is %v", "nil", *secCtx.RunAsGroup)
+	}
+
+	timeout := 2 * time.Minute
+	if err := f.WaitPodRunning(pod.ObjectMeta.Namespace, pod.ObjectMeta.Name, timeout); err != nil {
+		t.Fatalf("pod never reached state running")
+	}
+}
+
+func TestSecurityContextWithoutNamespaceAnnotationUndefinedContextFromConfig(t *testing.T) {
+	annotation := map[string]string{}
+	namespace, err := f.CreateTestNamespaceWithAnnotation(annotation)
+	if err != nil {
+		t.Fatalf("failed to create test namespace: %v", err)
+	}
+
+	ns := namespace.ObjectMeta.Name
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "karydia-e2e-test-pod",
+			Namespace: ns,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "redis",
+					Image: "redis",
+				},
+			},
+		},
+	}
+
+	createdPod, err := f.KubeClientset.CoreV1().Pods(ns).Create(pod)
+	if err != nil {
+		t.Fatalf("failed to create pod: %v", err)
+	}
+
+	secCtx := createdPod.Spec.SecurityContext
+	if secCtx == nil {
+		t.Fatalf("expected security context to be defined by admssion but is nil")
+	} else if *secCtx.RunAsUser != 65534 {
+		t.Fatalf("expected security context user id to be %v but is %v", 65534, *secCtx.RunAsUser)
+	} else if *secCtx.RunAsGroup != 65534 {
+		t.Fatalf("expected security context group id to be %v but is %v", 65534, *secCtx.RunAsGroup)
+	}
+
+	timeout := 2 * time.Minute
+	if err := f.WaitPodRunning(pod.ObjectMeta.Namespace, pod.ObjectMeta.Name, timeout); err != nil {
+		t.Fatalf("pod never reached state running")
+	}
+}

--- a/tests/e2e/framework/framework.go
+++ b/tests/e2e/framework/framework.go
@@ -212,7 +212,7 @@ spec:
 		},
 		Spec: v1alpha1.KarydiaConfigSpec{
 			AutomountServiceAccountToken: "change-default",
-			SeccompProfile:               "docker/default",
+			SeccompProfile:               "runtime/default",
 			NetworkPolicy:                "kube-system:karydia-default-network-policy",
 		},
 	}

--- a/tests/e2e/karydia_example_network_policy_test.go
+++ b/tests/e2e/karydia_example_network_policy_test.go
@@ -1,0 +1,142 @@
+// Copyright (C) 2019 SAP SE or an SAP affiliate company. All rights reserved.
+// This file is licensed under the Apache Software License, v. 2 except as
+// noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"os/exec"
+	"syscall"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	Success    int = 0
+	NoResponse int = 1
+	Error      int = 2
+)
+
+func execCommandAssertExitCode(t *testing.T, command string, expectedExitCode int) {
+	exitCode := Error
+
+	cmd := exec.Command(command)
+	err := cmd.Run()
+	if err != nil {
+		// try to get the exit code
+		if exitError, ok := err.(*exec.ExitError); ok {
+
+			// The program has exited with an exit code != 0
+			ws := exitError.Sys().(syscall.WaitStatus)
+			exitCode = ws.ExitStatus()
+			if exitCode != expectedExitCode {
+				t.Fatalf("Exit status with unexpected code: %d", exitCode)
+			}
+		}
+	} else {
+
+		// success, exitCode should be 0 if go is ok
+		exitCode = (cmd.ProcessState.Sys().(syscall.WaitStatus)).ExitStatus()
+		if exitCode != expectedExitCode {
+			t.Fatalf("Unallowed command is allowed but it should not be: %d", exitCode)
+		}
+	}
+}
+
+func TestNetworkPolicyLevel1(t *testing.T) {
+
+	var namespace *corev1.Namespace
+	var err error
+
+	namespace, err = f.CreateTestNamespace()
+	if err != nil {
+		t.Fatalf("failed to create test namespace: %v", err)
+	}
+
+	ns := namespace.ObjectMeta.Name
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "karydia-e2e-test-pod",
+			Namespace: ns,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "alpine",
+					Image: "alpine",
+				},
+			},
+		},
+	}
+
+	/*
+		svc := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "nginx-service",
+				Namespace: "kube-system",
+			},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{
+						Protocol:   corev1.ProtocolTCP,
+						Port:       80,
+						TargetPort: intstr.FromInt(8080),
+					},
+				},
+			},
+		}
+	*/
+
+	createdPod, err := f.KubeClientset.CoreV1().Pods(ns).Create(pod)
+	if err != nil {
+		t.Fatalf("Failed to create: " + err.Error())
+	}
+	podName := createdPod.ObjectMeta.Name
+
+	/*
+		createdService, err := f.KubeClientset.CoreV1().Services(ns).Create(svc)
+		if err != nil {
+			t.Fatalf("Failed to create: " + err.Error())
+		}
+		serviceName := createdService.ObjectMeta.Name
+	*/
+
+	pod.ObjectMeta.Name = "karydia-e2e-test-pod-2"
+	createdPod2, err := f.KubeClientset.CoreV1().Pods(ns).Create(pod)
+	if err != nil {
+		t.Fatalf("Failed to create: " + err.Error())
+	}
+	pod2IP := createdPod2.Status.PodIP
+
+	hostNetwork := createdPod.Status.HostIP
+
+	// ----------------------------------------------------------------------------------- //
+
+	cmd1 := "kubectl exec -it --namespace=" + ns + " " + podName + " -- ping -c 5 " + hostNetwork
+	execCommandAssertExitCode(t, cmd1, NoResponse)
+
+	cmd2 := "kubectl exec -it --namespace=" + ns + " " + podName + " -- ping -c 5 169.254.169.254"
+	execCommandAssertExitCode(t, cmd2, NoResponse)
+
+	cmd3 := "kubectl exec -it --namespace=" + ns + " " + podName + " -- ping -c 5 google.de"
+	execCommandAssertExitCode(t, cmd3, Success)
+
+	cmd4 := "kubectl exec -it --namespace=" + ns + " " + podName + " -- ping -c 5 " + pod2IP
+	execCommandAssertExitCode(t, cmd4, Success)
+
+}


### PR DESCRIPTION
<!-- Thanks for sending a PR -->

### Description
<!-- Feature description or reference to fixed issue -->

Level 1 Network Policy / karydia-default-network-policy added security for the following aspects:

1. block access to host network (static AWS)
2. block access to meta data services (AWS = GCP = Azure and Ali Cloud)
3. block access to kube-system namespace by allowing only necessary DNS traffic
We decided to be quite open (blacklist) because we weren't able to define all necessary network traffic.

Please note: In the next "Network Policy" version, the protection of host network will be implemented using labels and roles. We can't rely on a static or even dynamic IP range and we must use a layer of abstraction.

### Checklist
Before submitting this PR, please make sure:
- [x] you have added integration tests
- [x] your code builds clean with `make`
- [x] your code lets succeed unit tests with `make test`
- [x] your code lets succeed integration tests
- [x] you have documented new or changed features
<!-- Please delete options that are not relevant -->
