### PR TITLE
Consistently change 'docker/default' to 'runtime/default'

### DIFF
--- a/docs/demos/seccomp.md
+++ b/docs/demos/seccomp.md
@@ -58,6 +58,3 @@ unshare --user whoami
 
 => Operation not permitted
 ```
-
-# Overview of "docker/default" seccomp
-An overview of the not permitted sycalls can be found on the docker [website](https://docs.docker.com/engine/security/seccomp/).

--- a/install/charts/values.yaml
+++ b/install/charts/values.yaml
@@ -20,7 +20,7 @@ features:
 config:
   name: "karydia-config"
   automountServiceAccountToken: "change-default"
-  seccompProfile: "docker/default"
+  seccompProfile: "runtime/default"
   networkPolicy: "kube-system:karydia-default-network-policy"
   defaultNetworkPolicyExcludes: ""
 dev:

--- a/pkg/admission/karydia/admission_test.go
+++ b/pkg/admission/karydia/admission_test.go
@@ -38,7 +38,7 @@ func TestPodPlain(t *testing.T) {
 	namespace := &coreV1.Namespace{}
 	namespace.Name = "special"
 	namespace.Annotations = map[string]string{
-		"karydia.gardener.cloud/seccompProfile": "docker/default",
+		"karydia.gardener.cloud/seccompProfile": "runtime/default",
 	}
 	kubeobjects = append(kubeobjects, namespace)
 
@@ -117,7 +117,7 @@ func TestPodCorrectSeccomp(t *testing.T) {
 	namespace := &coreV1.Namespace{}
 	namespace.Name = "special"
 	namespace.Annotations = map[string]string{
-		"karydia.gardener.cloud/seccompProfile": "docker/default",
+		"karydia.gardener.cloud/seccompProfile": "runtime/default",
 	}
 	kubeobjects = append(kubeobjects, namespace)
 
@@ -136,7 +136,7 @@ func TestPodCorrectSeccomp(t *testing.T) {
 			Name:      "karydia-e2e-test-pod",
 			Namespace: "special",
 			Annotations: map[string]string{
-				"seccomp.security.alpha.kubernetes.io/pod": "docker/default",
+				"seccomp.security.alpha.kubernetes.io/pod": "runtime/default",
 			},
 		},
 		Spec: corev1.PodSpec{

--- a/tests/e2e/admission_seccomp_test.go
+++ b/tests/e2e/admission_seccomp_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestSeccompWithNamespaceAnnotationUndefinedProfile(t *testing.T) {
 	annotation := map[string]string{
-		"karydia.gardener.cloud/seccompProfile": "docker/default",
+		"karydia.gardener.cloud/seccompProfile": "runtime/default",
 	}
 	namespace, err := f.CreateTestNamespaceWithAnnotation(annotation)
 	if err != nil {
@@ -55,8 +55,8 @@ func TestSeccompWithNamespaceAnnotationUndefinedProfile(t *testing.T) {
 		t.Fatalf("failed to create pod: %v", err)
 	}
 
-	if profile := createdPod.ObjectMeta.Annotations["seccomp.security.alpha.kubernetes.io/pod"]; profile != "docker/default" {
-		t.Fatalf("expected seccomp profile to be %v but is %v", "docker/default", profile)
+	if profile := createdPod.ObjectMeta.Annotations["seccomp.security.alpha.kubernetes.io/pod"]; profile != "runtime/default" {
+		t.Fatalf("expected seccomp profile to be %v but is %v", "runtime/default", profile)
 	}
 
 	timeout := 2 * time.Minute
@@ -81,7 +81,7 @@ func TestSeccompWithNamespaceAnnotationDefinedProfile(t *testing.T) {
 			Name:      "karydia-e2e-test-pod",
 			Namespace: ns,
 			Annotations: map[string]string{
-				"seccomp.security.alpha.kubernetes.io/pod": "docker/default",
+				"seccomp.security.alpha.kubernetes.io/pod": "runtime/default",
 			},
 		},
 		Spec: corev1.PodSpec{
@@ -99,8 +99,8 @@ func TestSeccompWithNamespaceAnnotationDefinedProfile(t *testing.T) {
 		t.Fatalf("failed to create pod: %v", err)
 	}
 
-	if profile := createdPod.ObjectMeta.Annotations["seccomp.security.alpha.kubernetes.io/pod"]; profile != "docker/default" {
-		t.Fatalf("expected seccomp profile to be %v but is %v", "docker/default", profile)
+	if profile := createdPod.ObjectMeta.Annotations["seccomp.security.alpha.kubernetes.io/pod"]; profile != "runtime/default" {
+		t.Fatalf("expected seccomp profile to be %v but is %v", "runtime/default", profile)
 	}
 
 	timeout := 2 * time.Minute
@@ -138,8 +138,8 @@ func TestSeccompWithoutNamespaceAnnotationUndefinedProfileFromConfig(t *testing.
 		t.Fatalf("failed to create pod: %v", err)
 	}
 
-	if profile := createdPod.ObjectMeta.Annotations["seccomp.security.alpha.kubernetes.io/pod"]; profile != "docker/default" {
-		t.Fatalf("expected seccomp profile to be %v but is %v", "docker/default", profile)
+	if profile := createdPod.ObjectMeta.Annotations["seccomp.security.alpha.kubernetes.io/pod"]; profile != "runtime/default" {
+		t.Fatalf("expected seccomp profile to be %v but is %v", "runtime/default", profile)
 	}
 
 	timeout := 2 * time.Minute
@@ -203,7 +203,7 @@ func TestSeccompWithoutNamespaceAnnotationDefinedProfile(t *testing.T) {
 			Name:      "karydia-e2e-test-pod",
 			Namespace: ns,
 			Annotations: map[string]string{
-				"seccomp.security.alpha.kubernetes.io/pod": "docker/default",
+				"seccomp.security.alpha.kubernetes.io/pod": "runtime/default",
 			},
 		},
 		Spec: corev1.PodSpec{
@@ -221,8 +221,8 @@ func TestSeccompWithoutNamespaceAnnotationDefinedProfile(t *testing.T) {
 		t.Fatalf("failed to create pod: %v", err)
 	}
 
-	if profile := createdPod.ObjectMeta.Annotations["seccomp.security.alpha.kubernetes.io/pod"]; profile != "docker/default" {
-		t.Fatalf("expected seccomp profile to be %v but is %v", "docker/default", profile)
+	if profile := createdPod.ObjectMeta.Annotations["seccomp.security.alpha.kubernetes.io/pod"]; profile != "runtime/default" {
+		t.Fatalf("expected seccomp profile to be %v but is %v", "runtime/default", profile)
 	}
 
 	timeout := 2 * time.Minute

--- a/tests/e2e/framework/framework.go
+++ b/tests/e2e/framework/framework.go
@@ -212,7 +212,7 @@ spec:
 		},
 		Spec: v1alpha1.KarydiaConfigSpec{
 			AutomountServiceAccountToken: "change-default",
-			SeccompProfile:               "docker/default",
+			SeccompProfile:               "runtime/default",
 			NetworkPolicy:                "kube-system:karydia-default-network-policy",
 		},
 	}


### PR DESCRIPTION
### Description
This pull request changes the default seccomp profile from `docker/default` to `runtime/default`. As the [kubernetes documentation](https://kubernetes.io/docs/concepts/policy/pod-security-policy/#seccomp) states, this is the preferred value (and `docker/default` is deprecated).

Resolves #155.

### Checklist
Before submitting this PR, please make sure:
- [x] your code builds clean with `make`
- [x] your code lets succeed unit tests with `make test`
- [x] your code lets succeed integration tests
- [x] you have documented new or changed features
