### PR TITLE
Internal karydia feature annotations for network policies

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -45,6 +45,12 @@ The current network policy called `karydia-default-network-policy` has two secur
 
 Note: The network policy is still quite open. It uses a blacklisting approach and does not block Internet access (Egress).
 
+Karydia annotates the created network policy resources with the at the time and context valid security settings:
+
+| Resource | Annotation | Possible values |
+|---|---|---|
+| NetworkPolicy |karydia.gardener.cloud/networkPolicy.internal | (`config` \| `namespace`) /(\<`network-policy-name`\>) |
+
 ## Karydia Admission
 
 Karydia Admission (`--enable-karydia-admission`) offers features with the goal of a secure-by-default cluster setup. You can enable/disable this feature by setting `karydiaAdmission` to `true`/`false`.

--- a/pkg/controller/networkpolicy_reconciler_test.go
+++ b/pkg/controller/networkpolicy_reconciler_test.go
@@ -202,12 +202,14 @@ func TestReconcileNetworkPolicyUpate(t *testing.T) {
 	} else if !networkPoliciesAreEqual(f.defaultNetworkPolicies["karydia-default-network-policy"], reconciledPolicy) {
 		t.Error("No reconcilation happened")
 	}
+
 }
 
 func TestReconcileNetworkPolicyDelete(t *testing.T) {
 	namespace := &coreV1.Namespace{}
 	namespace.Name = "default"
 	f := newFixture(t)
+	assert := assert.New(t)
 	newNetworkPolicy := &networkingv1.NetworkPolicy{}
 	newNetworkPolicy.Name = "karydia-default-network-policy"
 	newNetworkPolicy.Namespace = "default"
@@ -222,6 +224,8 @@ func TestReconcileNetworkPolicyDelete(t *testing.T) {
 	} else if !networkPoliciesAreEqual(f.defaultNetworkPolicies["karydia-default-network-policy"], reconciledPolicy) {
 		t.Error("No reconcilation happened")
 	}
+	assert.Equal(len(reconciledPolicy.ObjectMeta.Annotations), 1, "network policy should contain internal karydia annotation")
+	assert.Contains(reconciledPolicy.ObjectMeta.Annotations["karydia.gardener.cloud/networkPolicy.internal"], "config")
 }
 
 func TestReconcileNetworkPolicyWithExisting(t *testing.T) {
@@ -249,6 +253,7 @@ func TestReconcileNetworkPolicyWithExisting(t *testing.T) {
 
 func TestReconcileNetworkPolicyCreateNamespace(t *testing.T) {
 	f := newFixture(t)
+	assert := assert.New(t)
 	newNamespace := &coreV1.Namespace{}
 	newNamespace.Name = "unittest"
 
@@ -262,6 +267,8 @@ func TestReconcileNetworkPolicyCreateNamespace(t *testing.T) {
 	} else if !networkPoliciesAreEqual(f.defaultNetworkPolicies["karydia-default-network-policy"], reconciledPolicy) {
 		t.Error("No reconcilation happened")
 	}
+	assert.Equal(len(reconciledPolicy.ObjectMeta.Annotations), 1, "network policy should contain internal karydia annotation")
+	assert.Contains(reconciledPolicy.ObjectMeta.Annotations["karydia.gardener.cloud/networkPolicy.internal"], "config")
 }
 
 func TestReconcileNetworkPolicyCreateExcludedNamespace(t *testing.T) {
@@ -281,6 +288,7 @@ func TestReconcileNetworkPolicyCreateExcludedNamespace(t *testing.T) {
 
 func TestReconcileNetworkPolicyCreateNamespaceWithAnnotation(t *testing.T) {
 	f := newFixture(t)
+	assert := assert.New(t)
 	newNamespace := &coreV1.Namespace{}
 	newNamespace.Name = "unittest"
 
@@ -304,4 +312,6 @@ func TestReconcileNetworkPolicyCreateNamespaceWithAnnotation(t *testing.T) {
 	} else if !networkPoliciesAreEqual(f.defaultNetworkPolicies["karydia-default-network-policy-l2"], reconciledPolicy) {
 		t.Error("No reconcilation happened")
 	}
+	assert.Equal(len(reconciledPolicy.ObjectMeta.Annotations), 1, "network policy should contain internal karydia annotation")
+	assert.Contains(reconciledPolicy.ObjectMeta.Annotations["karydia.gardener.cloud/networkPolicy.internal"], "namespace")
 }


### PR DESCRIPTION
<!-- Thanks for sending a PR -->

### Description
These annotations allow to indentify the source and value
of the network policies applied by karydia in each namespace. In case
of race-conditions this helps to identify the current state
and where settings have to be updated.

Solves #173 
### Checklist
Before submitting this PR, please make sure:
- [x] you have added unit tests
- [x] your code builds clean with `make`
- [x] your code lets succeed unit tests with `make test`
- [x] your code lets succeed integration tests
- [x] you have documented new or changed features
<!-- Please delete options that are not relevant -->
