### PR TITLE
Delete outdated network policy if annotation is added

### DIFF
--- a/install/charts/templates/rbac.yaml
+++ b/install/charts/templates/rbac.yaml
@@ -51,7 +51,7 @@ metadata:
 rules:
 - apiGroups: ["networking.k8s.io"]
   resources: ["networkpolicies"]
-  verbs: ["get", "watch", "list", "create", "patch", "update"]
+  verbs: ["get", "watch", "list", "create", "patch", "update", "delete"]
 
 ---
 

--- a/pkg/controller/networkpolicy_reconciler.go
+++ b/pkg/controller/networkpolicy_reconciler.go
@@ -411,7 +411,7 @@ func (reconciler *NetworkpolicyReconciler) createDefaultNetworkPolicy(namespace 
 		return err
 	}
 	if err := reconciler.deleteMultipleDefaultNetworkPolicies(namespace, networkpolicyName); err != nil {
-		klog.Errorf("Failed to delete network policy  %s", networkpolicyName)
+		reconciler.log.Errorln("Failed to delete network policy", networkpolicyName)
 		return err
 	}
 	return nil

--- a/pkg/controller/networkpolicy_reconciler_test.go
+++ b/pkg/controller/networkpolicy_reconciler_test.go
@@ -134,6 +134,10 @@ func (f *fixture) runNamespaceAdd(namespace string) {
 		f.t.Error("error syncing foo:", err)
 	}
 }
+func (f *fixture) runNamespaceUpdate(namespace string) {
+
+	f.runNamespaceAdd(namespace)
+}
 
 func getKey(networkpolicy *networkingv1.NetworkPolicy, t *testing.T) string {
 	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(networkpolicy)
@@ -314,4 +318,38 @@ func TestReconcileNetworkPolicyCreateNamespaceWithAnnotation(t *testing.T) {
 	}
 	assert.Equal(len(reconciledPolicy.ObjectMeta.Annotations), 1, "network policy should contain internal karydia annotation")
 	assert.Contains(reconciledPolicy.ObjectMeta.Annotations["karydia.gardener.cloud/networkPolicy.internal"], "namespace")
+}
+
+func TestReconcileNetworkPolicyUpdatedNamespace(t *testing.T) {
+	f := newFixture(t)
+	newNamespace := &coreV1.Namespace{}
+	newNamespace.Name = "unittest"
+
+	f.namespace = append(f.namespace, newNamespace)
+	f.kubeobjects = append(f.kubeobjects, newNamespace)
+
+	f.runNamespaceAdd(newNamespace.Name)
+	reconciledPolicy, err := f.kubeclient.NetworkingV1().NetworkPolicies(newNamespace.Name).Get(f.defaultNetworkPolicies["karydia-default-network-policy"].Name, meta_v1.GetOptions{})
+	if err != nil {
+		t.Errorf("No error expected")
+	} else if !networkPoliciesAreEqual(f.defaultNetworkPolicies["karydia-default-network-policy"], reconciledPolicy) {
+		t.Errorf("No reconcilation happened")
+	}
+
+	annotations := make(map[string]string)
+	annotations["karydia.gardener.cloud/networkPolicy"] = "karydia-default-network-policy-l2"
+	newNamespace.ObjectMeta.SetAnnotations(annotations)
+	f.runNamespaceUpdate(newNamespace.Name)
+
+	reconciledPolicy, err = f.kubeclient.NetworkingV1().NetworkPolicies(newNamespace.Name).Get(f.defaultNetworkPolicies["karydia-default-network-policy"].Name, meta_v1.GetOptions{})
+	if reconciledPolicy != nil {
+		t.Errorf("Default network policy should not be found")
+	}
+
+	reconciledPolicy, err = f.kubeclient.NetworkingV1().NetworkPolicies(newNamespace.Name).Get(f.defaultNetworkPolicies["karydia-default-network-policy-l2"].Name, meta_v1.GetOptions{})
+	if err != nil {
+		t.Errorf("No error expected")
+	} else if !networkPoliciesAreEqual(f.defaultNetworkPolicies["karydia-default-network-policy-l2"], reconciledPolicy) {
+		t.Errorf("No reconcilation happened")
+	}
 }

--- a/pkg/controller/networkpolicy_reconciler_test.go
+++ b/pkg/controller/networkpolicy_reconciler_test.go
@@ -331,9 +331,9 @@ func TestReconcileNetworkPolicyUpdatedNamespace(t *testing.T) {
 	f.runNamespaceAdd(newNamespace.Name)
 	reconciledPolicy, err := f.kubeclient.NetworkingV1().NetworkPolicies(newNamespace.Name).Get(f.defaultNetworkPolicies["karydia-default-network-policy"].Name, meta_v1.GetOptions{})
 	if err != nil {
-		t.Errorf("No error expected")
+		t.Error("No error expected")
 	} else if !networkPoliciesAreEqual(f.defaultNetworkPolicies["karydia-default-network-policy"], reconciledPolicy) {
-		t.Errorf("No reconcilation happened")
+		t.Error("No reconcilation happened")
 	}
 
 	annotations := make(map[string]string)
@@ -343,13 +343,13 @@ func TestReconcileNetworkPolicyUpdatedNamespace(t *testing.T) {
 
 	reconciledPolicy, err = f.kubeclient.NetworkingV1().NetworkPolicies(newNamespace.Name).Get(f.defaultNetworkPolicies["karydia-default-network-policy"].Name, meta_v1.GetOptions{})
 	if reconciledPolicy != nil {
-		t.Errorf("Default network policy should not be found")
+		t.Error("Default network policy should not be found")
 	}
 
 	reconciledPolicy, err = f.kubeclient.NetworkingV1().NetworkPolicies(newNamespace.Name).Get(f.defaultNetworkPolicies["karydia-default-network-policy-l2"].Name, meta_v1.GetOptions{})
 	if err != nil {
-		t.Errorf("No error expected")
+		t.Error("No error expected")
 	} else if !networkPoliciesAreEqual(f.defaultNetworkPolicies["karydia-default-network-policy-l2"], reconciledPolicy) {
-		t.Errorf("No reconcilation happened")
+		t.Error("No reconcilation happened")
 	}
 }

--- a/tests/e2e/karydia_network_policy_reconciler_test.go
+++ b/tests/e2e/karydia_network_policy_reconciler_test.go
@@ -168,22 +168,22 @@ func TestCreateNamespaceAndUpdateWithAnnotation(t *testing.T) {
 
 	_, err := f.KarydiaClientset.KarydiaV1alpha1().KarydiaNetworkPolicies().Create(defaultKarydiaNetworkPolicyL2)
 	if err != nil {
-		t.Fatalf("failed to create: %v", defaultKarydiaNetworkPolicyL2)
+		t.Fatal("failed to create:", defaultKarydiaNetworkPolicyL2)
 	}
 
 	namespace, err := f.CreateTestNamespace()
 	if err != nil {
-		t.Fatalf("failed to create test namespace: %v", err)
+		t.Fatal("failed to create test namespace:", err)
 	}
 
 	timeout := 3000 * time.Millisecond
 	if err := f.WaitNetworkPolicyCreated(namespace.GetName(), defaultNetworkPolicyName, timeout); err != nil {
-		t.Fatalf("failed to create default network policy for new namespace: %v", err)
+		t.Fatal("failed to create default network policy for new namespace:", err)
 	}
 
 	namespaceNetworkPolicy, err := f.KubeClientset.NetworkingV1().NetworkPolicies(namespace.GetName()).Get(defaultNetworkPolicyName, meta_v1.GetOptions{})
 	if err != nil {
-		t.Fatalf("failed to create default network policy for new namespace: %v", err)
+		t.Fatal("failed to create default network policy for new namespace:", err)
 	}
 
 	annotations := make(map[string]string)
@@ -191,29 +191,29 @@ func TestCreateNamespaceAndUpdateWithAnnotation(t *testing.T) {
 	namespace.SetAnnotations(annotations)
 	namespace, err = f.KubeClientset.CoreV1().Namespaces().Update(namespace)
 	if err != nil {
-		t.Fatalf("failed to update test namespace: %v", err)
+		t.Fatal("failed to update test namespace:", err)
 	}
 
 	if err := f.WaitNetworkPolicyCreated(namespace.GetName(), defaultNetworkPolicyL2Name, timeout); err != nil {
-		t.Fatalf("failed to create default network policy for new namespace: %v", err)
+		t.Fatal("failed to create default network policy for new namespace:", err)
 	}
 
 	_, err = f.KubeClientset.NetworkingV1().NetworkPolicies(namespace.GetName()).Get(defaultNetworkPolicyName, meta_v1.GetOptions{})
 	if err == nil {
-		t.Fatalf("Default level 1 network policy should not be found")
+		t.Fatal("Default level 1 network policy should not be found")
 	}
 
 	namespaceNetworkPolicy, err = f.KubeClientset.NetworkingV1().NetworkPolicies(namespace.GetName()).Get(defaultNetworkPolicyL2Name, meta_v1.GetOptions{})
 	if err != nil {
-		t.Fatalf("failed to create default network policy for new namespace: %v", err)
+		t.Fatal("failed to create default network policy for new namespace:", err)
 	}
 
 	if !networkPoliciesAreEqual(namespaceNetworkPolicy, defaultNetworkPolicy) {
-		t.Fatalf("Network policy for created namespace is not equal to the default network policy: %v", err)
+		t.Fatal("Network policy for created namespace is not equal to the default network policy:", err)
 	}
 
 	if err := f.KarydiaClientset.KarydiaV1alpha1().KarydiaNetworkPolicies().Delete(defaultNetworkPolicyL2Name, &meta_v1.DeleteOptions{}); err != nil {
-		t.Fatalf("Failed to delete karydia default network policy l2: %v", err)
+		t.Fatal("Failed to delete karydia default network policy l2:", err)
 	}
 }
 func TestGetKarydiaNetworkPolicyForExcludedNamespace(t *testing.T) {

--- a/tests/e2e/karydia_network_policy_reconciler_test.go
+++ b/tests/e2e/karydia_network_policy_reconciler_test.go
@@ -147,6 +147,75 @@ func TestCreateKarydiaNetworkPolicyForAnnotatedNamespace(t *testing.T) {
 		t.Fatal("Failed to delete karydia default network policy l2:", err)
 	}
 }
+func TestCreateNamespaceAndUpdateWithAnnotation(t *testing.T) {
+	defaultNetworkPolicy := &networkingv1.NetworkPolicy{}
+	defaultNetworkPolicy.Name = defaultNetworkPolicyL2Name
+	defaultNetworkPolicy.Spec = networkingv1.NetworkPolicySpec{
+		PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+	}
+
+	defaultKarydiaNetworkPolicyL2 := &v1alpha1.KarydiaNetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"app": "karydia-e2e-test",
+			},
+			Name: defaultNetworkPolicyL2Name,
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+		},
+	}
+
+	_, err := f.KarydiaClientset.KarydiaV1alpha1().KarydiaNetworkPolicies().Create(defaultKarydiaNetworkPolicyL2)
+	if err != nil {
+		t.Fatalf("failed to create: %v", defaultKarydiaNetworkPolicyL2)
+	}
+
+	namespace, err := f.CreateTestNamespace()
+	if err != nil {
+		t.Fatalf("failed to create test namespace: %v", err)
+	}
+
+	timeout := 3000 * time.Millisecond
+	if err := f.WaitNetworkPolicyCreated(namespace.GetName(), defaultNetworkPolicyName, timeout); err != nil {
+		t.Fatalf("failed to create default network policy for new namespace: %v", err)
+	}
+
+	namespaceNetworkPolicy, err := f.KubeClientset.NetworkingV1().NetworkPolicies(namespace.GetName()).Get(defaultNetworkPolicyName, meta_v1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to create default network policy for new namespace: %v", err)
+	}
+
+	annotations := make(map[string]string)
+	annotations["karydia.gardener.cloud/networkPolicy"] = defaultNetworkPolicyL2Name
+	namespace.SetAnnotations(annotations)
+	namespace, err = f.KubeClientset.CoreV1().Namespaces().Update(namespace)
+	if err != nil {
+		t.Fatalf("failed to update test namespace: %v", err)
+	}
+
+	if err := f.WaitNetworkPolicyCreated(namespace.GetName(), defaultNetworkPolicyL2Name, timeout); err != nil {
+		t.Fatalf("failed to create default network policy for new namespace: %v", err)
+	}
+
+	_, err = f.KubeClientset.NetworkingV1().NetworkPolicies(namespace.GetName()).Get(defaultNetworkPolicyName, meta_v1.GetOptions{})
+	if err == nil {
+		t.Fatalf("Default level 1 network policy should not be found")
+	}
+
+	namespaceNetworkPolicy, err = f.KubeClientset.NetworkingV1().NetworkPolicies(namespace.GetName()).Get(defaultNetworkPolicyL2Name, meta_v1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to create default network policy for new namespace: %v", err)
+	}
+
+	if !networkPoliciesAreEqual(namespaceNetworkPolicy, defaultNetworkPolicy) {
+		t.Fatalf("Network policy for created namespace is not equal to the default network policy: %v", err)
+	}
+
+	if err := f.KarydiaClientset.KarydiaV1alpha1().KarydiaNetworkPolicies().Delete(defaultNetworkPolicyL2Name, &meta_v1.DeleteOptions{}); err != nil {
+		t.Fatalf("Failed to delete karydia default network policy l2: %v", err)
+	}
+}
 func TestGetKarydiaNetworkPolicyForExcludedNamespace(t *testing.T) {
 	if _, err := f.KubeClientset.NetworkingV1().NetworkPolicies("kube-system").Get(defaultNetworkPolicyName, meta_v1.GetOptions{}); err == nil {
 		t.Fatal("Default network policy should not be found for excluded namespace")


### PR DESCRIPTION
<!-- Thanks for sending a PR -->

### Description
If you change the network policy assignment on a namespace the old network policy will now be deleted.
Solves #174 


### Checklist
Before submitting this PR, please make sure:
- [x] you have added unit tests
- [x] you have added integration tests
- [x] your code builds clean with `make`
- [x] your code lets succeed unit tests with `make test`
- [x] your code lets succeed integration tests

<!-- Please delete options that are not relevant -->
