### PR TITLE
[WORKAROUND] #183

### DIFF
--- a/install/charts/templates/workaround-annotate-kube-system-namespace.yaml
+++ b/install/charts/templates/workaround-annotate-kube-system-namespace.yaml
@@ -1,0 +1,50 @@
+# Copyright (C) 2019 SAP SE or an SAP affiliate company. All rights reserved.
+# This file is licensed under the Apache Software License, v. 2 except as
+# noted otherwise in the LICENSE file.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [WORKAROUND] for issue: https://github.com/karydia/karydia/issues/183
+#   It adds annotations to the 'kube-system' namespace for deactivating the
+#   'seccompProfile' and 'podSecurityContext' admission features in that
+#   namespace. Additionally, it adds one annotation for being able to
+#   identify 'kube-system' namespaces which used this workaround for cleaning
+#   things up later on.
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Values.metadata.name }}-workaround
+  namespace: {{ .Values.metadata.namespace }}
+  labels:
+    app: {{ .Values.metadata.labelApp }}
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+spec:
+  template:
+    spec:
+      serviceAccountName: tiller
+      restartPolicy: Never
+      containers:
+      - name: {{ .Values.metadata.name }}-annotater
+        image: k8s.gcr.io/hyperkube:v1.15.2
+        command:
+        - kubectl
+        - annotate
+        - --overwrite=true
+        - namespace
+        - kube-system
+        - karydia.gardener.cloud/workaroundForIssue=183
+        - karydia.gardener.cloud/seccompProfile=unconfined
+        - karydia.gardener.cloud/podSecurityContext=none


### PR DESCRIPTION
<!-- Thanks for sending a PR -->

### Description
<!-- Feature description or reference to fixed issue -->
This workaround is only valid till a consistent solution for issue #183 is found.
It adds the following annotations to the 'kube-system' namespace for deactivating the 'seccompProfile' and 'podSecurityContext' admission features (https://github.com/karydia/karydia/blob/master/docs/features.md#karydia-admission) in that namespace. Additionally, it adds one annotation for being able to identify 'kube-system' namespaces which used this workaround for cleaning things up later on.
- 'karydia.gardener.cloud/workaroundForIssue=183'
- 'karydia.gardener.cloud/seccompProfile=unconfined'
- 'karydia.gardener.cloud/podSecurityContext=none'

### Checklist
Before submitting this PR, please make sure:
- [x] your code builds clean with `make`
- [x] your code lets succeed unit tests with `make test`
- [x] your code lets succeed integration tests
<!-- Please delete options that are not relevant -->
