### PR TITLE
[LOGGING] Unification

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,11 @@
 .idea/
 .ci/
+.github/
 bin/
 contrib/
 docs/
 logo/
-manifests-dev/
 manifests/
 
+cov.out
 karydia*.pem

--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,7 @@
 
 .idea/
 bin/
-
-karydia*.pem
-cov.out
-
 manifests/
+
+cov.out
+karydia*.pem

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-# Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+# Copyright (C) 2019 SAP SE or an SAP affiliate company. All rights reserved.
+# This file is licensed under the Apache Software License, v. 2 except as
+# noted otherwise in the LICENSE file.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -878,7 +878,6 @@
     "k8s.io/code-generator/cmd/defaulter-gen",
     "k8s.io/code-generator/cmd/informer-gen",
     "k8s.io/code-generator/cmd/lister-gen",
-    "k8s.io/klog",
     "k8s.io/kubernetes/pkg/api/v1/pod",
     "k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac",
   ]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,28 +1,18 @@
-# Gopkg.toml example
+# Copyright (C) 2019 SAP SE or an SAP affiliate company. All rights reserved.
+# This file is licensed under the Apache Software License, v. 2 except as
+# noted otherwise in the LICENSE file.
 #
-# Refer to https://golang.github.io/dep/docs/Gopkg.toml.html
-# for detailed Gopkg.toml documentation.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# required = ["github.com/user/thing/cmd/thing"]
-# ignored = ["github.com/user/project/pkgX", "bitbucket.org/user/project/pkgA/pkgY"]
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
-# [[constraint]]
-#   name = "github.com/user/project"
-#   version = "1.0.0"
-#
-# [[constraint]]
-#   name = "github.com/user/project2"
-#   branch = "dev"
-#   source = "github.com/myfork/project2"
-#
-# [[override]]
-#   name = "github.com/x/y"
-#   version = "2.4.0"
-#
-# [prune]
-#   non-go = false
-#   go-tests = true
-#   unused-packages = true
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # Force dep to vendor the code generators, which aren't imported just used at dev time.
 required = [

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,3 +1,3 @@
 # Karydia
 
-Copyright (c) 2018-2019 SAP SE or an SAP affiliate company. All rights reserved.
+Copyright (C) 2018-2019 SAP SE or an SAP affiliate company. All rights reserved.

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -1,4 +1,6 @@
-// Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+// Copyright (C) 2019 SAP SE or an SAP affiliate company. All rights reserved.
+// This file is licensed under the Apache Software License, v. 2 except as
+// noted otherwise in the LICENSE file.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,13 +18,13 @@ package cmd
 
 import (
 	"flag"
-	"fmt"
-	"os"
-
-	homedir "github.com/mitchellh/go-homedir"
+	"github.com/karydia/karydia/pkg/logger"
+	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
+
+var log = logger.NewComponentLogger("cmd")
 
 var cfgFile string
 
@@ -33,8 +35,7 @@ var rootCmd = &cobra.Command{
 
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		log.Fatalln(err)
 	}
 }
 
@@ -56,8 +57,7 @@ func initConfig() {
 	} else {
 		home, err := homedir.Dir()
 		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
+			log.Fatalln(err)
 		}
 		viper.AddConfigPath(home)
 		viper.SetConfigType("yaml")
@@ -66,6 +66,6 @@ func initConfig() {
 	viper.SetEnvPrefix("KARYDIA")
 	viper.AutomaticEnv()
 	if err := viper.ReadInConfig(); err == nil {
-		fmt.Println("Using config file:", viper.ConfigFileUsed())
+		log.Debugln("Using config file:", viper.ConfigFileUsed())
 	}
 }

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -24,7 +24,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-var log = logger.NewComponentLogger("cmd")
+var log = logger.NewComponentLogger(logger.GetCallersPackagename())
 
 var cfgFile string
 

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -24,7 +24,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-var log = logger.NewComponentLogger(logger.GetCallersPackagename())
+var log *logger.Logger
 
 var cfgFile string
 
@@ -33,13 +33,10 @@ var rootCmd = &cobra.Command{
 	Short: "karydia - Kubernetes security walnut",
 }
 
-func Execute() {
-	if err := rootCmd.Execute(); err != nil {
-		log.Fatalln(err)
-	}
-}
-
 func init() {
+	rootCmd.PersistentFlags().StringVar(&logger.LogLevel, "log-level", logger.LogLevel, "log level to set a specific level for logging: debug | info | warn | error | fatal | panic")
+	log = logger.NewComponentLogger(logger.GetCallersPackagename())
+
 	cobra.OnInitialize(initConfig)
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.karydia.yaml)")
 
@@ -67,5 +64,11 @@ func initConfig() {
 	viper.AutomaticEnv()
 	if err := viper.ReadInConfig(); err == nil {
 		log.Debugln("Using config file:", viper.ConfigFileUsed())
+	}
+}
+
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		log.Fatalln(err)
 	}
 }

--- a/cli/cmd/runserver.go
+++ b/cli/cmd/runserver.go
@@ -86,7 +86,7 @@ func runserverFunc(cmd *cobra.Command, args []string) {
 
 	tlsConfig, err := tls.CreateTLSConfig(viper.GetString("tls-cert"), viper.GetString("tls-key"))
 	if err != nil {
-		log.Fatalf("Failed to create TLS config: %v\n", err)
+		log.Fatalln("Failed to create TLS config:", err)
 	}
 
 	ctx, cancelCtx := context.WithCancel(context.Background())
@@ -94,7 +94,7 @@ func runserverFunc(cmd *cobra.Command, args []string) {
 
 	webHook, err := webhook.New(&webhook.Config{})
 	if err != nil {
-		log.Fatalf("Failed to load webhook: %v\n", err)
+		log.Fatalln("Failed to load webhook:", err)
 	}
 
 	kubeConfig := viper.GetString("kubeconfig")
@@ -102,28 +102,28 @@ func runserverFunc(cmd *cobra.Command, args []string) {
 
 	kubeClientset, err := k8sutil.Clientset(kubeServer, kubeConfig)
 	if err != nil {
-		log.Fatalf("Failed to create clientset: %v\n", err)
+		log.Fatalln("Failed to create clientset:", err)
 	}
 
 	cfg, err := clientcmd.BuildConfigFromFlags(kubeServer, kubeConfig)
 	if err != nil {
-		log.Fatalf("Failed to build kubeconfig: %v\n", err)
+		log.Fatalln("Failed to build kubeconfig:", err)
 	}
 	karydiaClientset, err := clientset.NewForConfig(cfg)
 	if err != nil {
-		log.Fatalf("Failed to build karydia clientset: %v\n", err)
+		log.Fatalln("Failed to build karydia clientset:", err)
 	}
 
 	karydiaConfig, err := karydiaClientset.KarydiaV1alpha1().KarydiaConfigs().Get(viper.GetString("config"), metav1.GetOptions{})
 
 	if err != nil {
-		log.Fatalf("Failed to load karydia config: %v\n", err)
+		log.Fatalln("Failed to load karydia config:", err)
 	}
-	log.Infof("KarydiaConfig Name: %s\n", karydiaConfig.Name)
-	log.Infof("KarydiaConfig AutomountServiceAccountToken: %s\n", karydiaConfig.Spec.AutomountServiceAccountToken)
-	log.Infof("KarydiaConfig SeccompProfile: %s\n", karydiaConfig.Spec.SeccompProfile)
-	log.Infof("KarydiaConfig NetworkPolicy: %s\n", karydiaConfig.Spec.NetworkPolicy)
-	log.Infof("KarydiaConfig PodSecurityContext: %s\n", karydiaConfig.Spec.PodSecurityContext)
+	log.Infoln("KarydiaConfig Name:", karydiaConfig.Name)
+	log.Infoln("KarydiaConfig AutomountServiceAccountToken:", karydiaConfig.Spec.AutomountServiceAccountToken)
+	log.Infoln("KarydiaConfig SeccompProfile:", karydiaConfig.Spec.SeccompProfile)
+	log.Infoln("KarydiaConfig NetworkPolicy:", karydiaConfig.Spec.NetworkPolicy)
+	log.Infoln("KarydiaConfig PodSecurityContext:", karydiaConfig.Spec.PodSecurityContext)
 
 	if enableKarydiaAdmission {
 		karydiaAdmission, err := karydiaadmission.New(&karydiaadmission.Config{
@@ -131,7 +131,7 @@ func runserverFunc(cmd *cobra.Command, args []string) {
 			KarydiaConfig: karydiaConfig,
 		})
 		if err != nil {
-			log.Fatalf("Failed to load karydia admission: %v\n", err)
+			log.Fatalln("Failed to load karydia admission:", err)
 		}
 
 		webHook.RegisterAdmissionPlugin(karydiaAdmission)
@@ -144,7 +144,7 @@ func runserverFunc(cmd *cobra.Command, args []string) {
 		karydiaDefaultNetworkPolicyName := karydiaConfig.Spec.NetworkPolicy
 		karydiaDefaulNetworkPolicy, err := karydiaClientset.KarydiaV1alpha1().KarydiaNetworkPolicies().Get(karydiaDefaultNetworkPolicyName, metav1.GetOptions{})
 		if err != nil {
-			log.Fatalf("Failed to load KarydiaDefaultNetworkPolicy : %v\n", err)
+			log.Fatalln("Failed to load KarydiaDefaultNetworkPolicy:", err)
 		}
 		var policy networkingv1.NetworkPolicy
 		policy.Spec = *karydiaDefaulNetworkPolicy.Spec.DeepCopy()
@@ -156,11 +156,11 @@ func runserverFunc(cmd *cobra.Command, args []string) {
 	if enableController {
 		cfg, err := clientcmd.BuildConfigFromFlags(kubeServer, kubeConfig)
 		if err != nil {
-			log.Fatalf("error building kubeconfig: %v", err)
+			log.Fatalln("error building kubeconfig:", err)
 		}
 		kubeClientset, err := kubernetes.NewForConfig(cfg)
 		if err != nil {
-			log.Fatalf("error building kubernetes clientset: %v", err)
+			log.Fatalln("error building kubernetes clientset:", err)
 		}
 		kubeInformerFactory = kubeinformers.NewSharedInformerFactory(kubeClientset, resyncInterval)
 		namespaceInformer := kubeInformerFactory.Core().V1().Namespaces()
@@ -176,7 +176,7 @@ func runserverFunc(cmd *cobra.Command, args []string) {
 
 	s, err := server.New(serverConfig, webHook)
 	if err != nil {
-		log.Fatalf("Failed to load server: %v\n", err)
+		log.Fatalln("Failed to load server:", err)
 	}
 
 	karydiaInformerFactory = karydiainformers.NewSharedInformerFactory(karydiaClientset, resyncInterval)
@@ -188,7 +188,7 @@ func runserverFunc(cmd *cobra.Command, args []string) {
 	go func() {
 		defer wg.Done()
 		if err := s.ListenAndServe(); err != http.ErrServerClosed {
-			log.Errorf("HTTP ListenAndServe error: %v\n", err)
+			log.Errorln("HTTP ListenAndServe error:", err)
 		}
 	}()
 
@@ -202,7 +202,7 @@ func runserverFunc(cmd *cobra.Command, args []string) {
 		defer cancelShutdownCtx()
 
 		if err := s.Shutdown(shutdownCtx); err != nil {
-			log.Errorf("HTTP Shutdown error: %v\n", err)
+			log.Errorln("HTTP Shutdown error:", err)
 		}
 	}()
 
@@ -211,7 +211,7 @@ func runserverFunc(cmd *cobra.Command, args []string) {
 		defer wg.Done()
 		karydiaInformerFactory.Start(ctx.Done())
 		if err := karydiaConfigReconciler.Run(2, ctx.Done()); err != nil {
-			log.Errorf("Error running config reconciler: %v\n", err)
+			log.Errorln("Error running config reconciler:", err)
 		}
 	}()
 
@@ -221,7 +221,7 @@ func runserverFunc(cmd *cobra.Command, args []string) {
 			defer wg.Done()
 			kubeInformerFactory.Start(ctx.Done())
 			if err := reconciler.Run(2, ctx.Done()); err != nil {
-				log.Errorf("Error running controller: %v\n", err)
+				log.Errorln("Error running controller:", err)
 			}
 		}()
 	}

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"fmt"
-
 	"github.com/spf13/cobra"
 
 	"github.com/karydia/karydia"

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -1,4 +1,6 @@
-// Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+// Copyright (C) 2019 SAP SE or an SAP affiliate company. All rights reserved.
+// This file is licensed under the Apache Software License, v. 2 except as
+// noted otherwise in the LICENSE file.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cli/main.go
+++ b/cli/main.go
@@ -1,4 +1,6 @@
-// Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+// Copyright (C) 2019 SAP SE or an SAP affiliate company. All rights reserved.
+// This file is licensed under the Apache Software License, v. 2 except as
+// noted otherwise in the LICENSE file.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/install/charts/templates/deployment.yaml
+++ b/install/charts/templates/deployment.yaml
@@ -53,6 +53,8 @@ spec:
           - karydia
           {{- end }}
           - runserver
+          - --log-level
+          - {{ .Values.log.level }}
           - --tls-cert
           - /etc/karydia/tls/cert.pem
           - --tls-key

--- a/install/charts/values.yaml
+++ b/install/charts/values.yaml
@@ -24,6 +24,8 @@ config:
   networkPolicy: "karydia-default-network-policy"
   podSecurityContext: "nobody"
   defaultNetworkPolicyExcludes: ""
+log:
+  level: "info"
 dev:
   active: false
   timeoutIncreaseValue: 0

--- a/pkg/admission/interface.go
+++ b/pkg/admission/interface.go
@@ -1,4 +1,6 @@
-// Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+// Copyright (C) 2019 SAP SE or an SAP affiliate company. All rights reserved.
+// This file is licensed under the Apache Software License, v. 2 except as
+// noted otherwise in the LICENSE file.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/admission/karydia/admission.go
+++ b/pkg/admission/karydia/admission.go
@@ -19,11 +19,10 @@ package karydia
 import (
 	"encoding/json"
 	"fmt"
-
 	"github.com/karydia/karydia/pkg/apis/karydia/v1alpha1"
+	"github.com/karydia/karydia/pkg/logger"
 
 	"github.com/karydia/karydia/pkg/k8sutil"
-	"github.com/sirupsen/logrus"
 	"k8s.io/api/admission/v1beta1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,7 +33,7 @@ var kindPod = metav1.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}
 var kindServiceAccount = metav1.GroupVersionKind{Group: "", Version: "v1", Kind: "ServiceAccount"}
 
 type KarydiaAdmission struct {
-	logger        *logrus.Logger
+	logger        *logger.Logger
 	kubeClientset kubernetes.Interface
 	karydiaConfig *v1alpha1.KarydiaConfig
 }
@@ -66,8 +65,7 @@ type Patches struct {
 }
 
 func New(config *Config) (*KarydiaAdmission, error) {
-	logger := logrus.New()
-	logger.Level = logrus.InfoLevel
+	logger := logger.NewComponentLogger("admission")
 
 	return &KarydiaAdmission{
 		logger:        logger,

--- a/pkg/admission/karydia/admission.go
+++ b/pkg/admission/karydia/admission.go
@@ -65,7 +65,7 @@ type Patches struct {
 }
 
 func New(config *Config) (*KarydiaAdmission, error) {
-	logger := logger.NewComponentLogger("admission")
+	logger := logger.NewComponentLogger(logger.GetCallersFilename())
 
 	return &KarydiaAdmission{
 		logger:        logger,
@@ -84,13 +84,13 @@ func (k *KarydiaAdmission) Admit(ar v1beta1.AdmissionReview, mutationAllowed boo
 	case kindPod:
 		pod, err := decodePod(req.Object.Raw)
 		if err != nil {
-			k.logger.Errorf("failed to decode object: %v", err)
+			k.logger.Errorln("failed to decode object:", err)
 			return k8sutil.ErrToAdmissionResponse(err)
 		}
 
 		namespace, err := k.getNamespaceFromAdmissionRequest(*req)
 		if err != nil {
-			k.logger.Errorf("%v", err)
+			k.logger.Errorln(err)
 			return k8sutil.ErrToAdmissionResponse(err)
 		}
 
@@ -101,13 +101,13 @@ func (k *KarydiaAdmission) Admit(ar v1beta1.AdmissionReview, mutationAllowed boo
 	case kindServiceAccount:
 		sAcc, err := decodeServiceAccount(req.Object.Raw)
 		if err != nil {
-			k.logger.Errorf("failed to decode object: %v", err)
+			k.logger.Errorln("failed to decode object:", err)
 			return k8sutil.ErrToAdmissionResponse(err)
 		}
 
 		namespace, err := k.getNamespaceFromAdmissionRequest(*req)
 		if err != nil {
-			k.logger.Errorf("%v", err)
+			k.logger.Errorln(err)
 			return k8sutil.ErrToAdmissionResponse(err)
 		}
 

--- a/pkg/admission/karydia/admission_test.go
+++ b/pkg/admission/karydia/admission_test.go
@@ -18,8 +18,6 @@ package karydia
 
 import (
 	"encoding/json"
-	"fmt"
-	"os"
 	"testing"
 
 	jsonpatch "github.com/evanphx/json-patch"
@@ -49,8 +47,7 @@ func TestPodPlainSeccomp(t *testing.T) {
 		KubeClientset: kubeclient,
 	})
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to load karydia admission: %v\n", err)
-		os.Exit(1)
+		t.Fatalf("Failed to load karydia admission: %v\n", err)
 	}
 
 	pod := &corev1.Pod{
@@ -128,8 +125,7 @@ func TestPodPlainSecContext(t *testing.T) {
 		KubeClientset: kubeclient,
 	})
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to load karydia admission: %v\n", err)
-		os.Exit(1)
+		t.Fatalf("Failed to load karydia admission: %v\n", err)
 	}
 
 	pod := &corev1.Pod{
@@ -207,8 +203,7 @@ func TestPodDefinedSecContext(t *testing.T) {
 		KubeClientset: kubeclient,
 	})
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to load karydia admission: %v\n", err)
-		os.Exit(1)
+		t.Fatalf("Failed to load karydia admission: %v\n", err)
 	}
 
 	var uid int64 = 1000
@@ -291,8 +286,7 @@ func TestPodCorrectSeccomp(t *testing.T) {
 		KubeClientset: kubeclient,
 	})
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to load karydia admission: %v\n", err)
-		os.Exit(1)
+		t.Fatalf("Failed to load karydia admission: %v\n", err)
 	}
 
 	pod := &corev1.Pod{
@@ -358,8 +352,7 @@ func TestServiceAccountPlain(t *testing.T) {
 		KubeClientset: kubeclient,
 	})
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to load karydia admission: %v\n", err)
-		os.Exit(1)
+		t.Fatalf("Failed to load karydia admission: %v\n", err)
 	}
 
 	servieAccount := &corev1.ServiceAccount{
@@ -429,8 +422,7 @@ func TestServiceAccountAutomountDefined(t *testing.T) {
 		KubeClientset: kubeclient,
 	})
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to load karydia admission: %v\n", err)
-		os.Exit(1)
+		t.Fatalf("Failed to load karydia admission: %v\n", err)
 	}
 
 	var vTrue = true
@@ -503,8 +495,7 @@ func TestServiceAccountDefault(t *testing.T) {
 		KubeClientset: kubeclient,
 	})
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to load karydia admission: %v\n", err)
-		os.Exit(1)
+		t.Fatalf("Failed to load karydia admission: %v\n", err)
 	}
 
 	servieAccount := &corev1.ServiceAccount{
@@ -565,8 +556,7 @@ func TestInvalidAdmissionReview(t *testing.T) {
 		KubeClientset: kubeclient,
 	})
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to load karydia admission: %v\n", err)
-		os.Exit(1)
+		t.Fatalf("Failed to load karydia admission: %v\n", err)
 	}
 
 	/* DELETE operation -> is currently ignored */
@@ -680,8 +670,7 @@ func TestInvalidDecodeOfResources(t *testing.T) {
 		KubeClientset: kubeclient,
 	})
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to load karydia admission: %v\n", err)
-		os.Exit(1)
+		t.Fatalf("Failed to load karydia admission: %v\n", err)
 	}
 
 	invalidRawServiceAccount := make([]byte, 4)

--- a/pkg/admission/karydia/admission_test.go
+++ b/pkg/admission/karydia/admission_test.go
@@ -47,7 +47,7 @@ func TestPodPlainSeccomp(t *testing.T) {
 		KubeClientset: kubeclient,
 	})
 	if err != nil {
-		t.Fatalf("Failed to load karydia admission: %v\n", err)
+		t.Fatal("Failed to load karydia admission:", err)
 	}
 
 	pod := &corev1.Pod{
@@ -79,32 +79,32 @@ func TestPodPlainSeccomp(t *testing.T) {
 
 	mutationResponse := karydiaAdmission.Admit(ar, true)
 	if !mutationResponse.Allowed {
-		t.Errorf("expected mutation response to be true but is %v", mutationResponse.Allowed)
+		t.Error("expected mutation response to be true but is", mutationResponse.Allowed)
 	}
 
 	var patches []patchOperation
 	err = json.Unmarshal(mutationResponse.Patch, &patches)
 	if len(patches) != 4 {
-		t.Errorf("expected number of patches to be 4 but is %v", len(patches))
+		t.Error("expected number of patches to be 4 but is", len(patches))
 	}
 
 	t.Log(patches)
 
 	mutatedPod, err := patchPodRaw(*pod, mutationResponse.Patch)
 	if err != nil {
-		t.Errorf("failed to apply patches: %+v", err)
+		t.Error("failed to apply patches:", err)
 	}
 
 	validationResponse := karydiaAdmission.Admit(ar, false)
 	if validationResponse.Allowed {
-		t.Errorf("expected validation response to be false but is %v", validationResponse.Allowed)
+		t.Error("expected validation response to be false but is", validationResponse.Allowed)
 	}
 
 	ar.Request.Object.Raw, _ = json.Marshal(mutatedPod)
 
 	validationResponse = karydiaAdmission.Admit(ar, false)
 	if !validationResponse.Allowed {
-		t.Errorf("expected validation response to be true but is %v", validationResponse.Allowed)
+		t.Error("expected validation response to be true but is", validationResponse.Allowed)
 	}
 
 }
@@ -125,7 +125,7 @@ func TestPodPlainSecContext(t *testing.T) {
 		KubeClientset: kubeclient,
 	})
 	if err != nil {
-		t.Fatalf("Failed to load karydia admission: %v\n", err)
+		t.Fatal("Failed to load karydia admission:", err)
 	}
 
 	pod := &corev1.Pod{
@@ -157,32 +157,32 @@ func TestPodPlainSecContext(t *testing.T) {
 
 	mutationResponse := karydiaAdmission.Admit(ar, true)
 	if !mutationResponse.Allowed {
-		t.Errorf("expected mutation response to be true but is %v", mutationResponse.Allowed)
+		t.Error("expected mutation response to be true but is", mutationResponse.Allowed)
 	}
 
 	var patches []patchOperation
 	err = json.Unmarshal(mutationResponse.Patch, &patches)
 	if len(patches) != 2 {
-		t.Errorf("expected number of patches to be 2 but is %v", len(patches))
+		t.Error("expected number of patches to be 2 but is", len(patches))
 	}
 
 	t.Log(patches)
 
 	mutatedPod, err := patchPodRaw(*pod, mutationResponse.Patch)
 	if err != nil {
-		t.Errorf("failed to apply patches: %+v", err)
+		t.Error("failed to apply patches:", err)
 	}
 
 	validationResponse := karydiaAdmission.Admit(ar, false)
 	if validationResponse.Allowed {
-		t.Errorf("expected validation response to be false but is %v", validationResponse.Allowed)
+		t.Error("expected validation response to be false but is", validationResponse.Allowed)
 	}
 
 	ar.Request.Object.Raw, _ = json.Marshal(mutatedPod)
 
 	validationResponse = karydiaAdmission.Admit(ar, false)
 	if !validationResponse.Allowed {
-		t.Errorf("expected validation response to be true but is %v", validationResponse.Allowed)
+		t.Error("expected validation response to be true but is", validationResponse.Allowed)
 	}
 
 }
@@ -203,7 +203,7 @@ func TestPodDefinedSecContext(t *testing.T) {
 		KubeClientset: kubeclient,
 	})
 	if err != nil {
-		t.Fatalf("Failed to load karydia admission: %v\n", err)
+		t.Fatal("Failed to load karydia admission:", err)
 	}
 
 	var uid int64 = 1000
@@ -240,32 +240,32 @@ func TestPodDefinedSecContext(t *testing.T) {
 
 	mutationResponse := karydiaAdmission.Admit(ar, true)
 	if !mutationResponse.Allowed {
-		t.Errorf("expected mutation response to be true but is %v", mutationResponse.Allowed)
+		t.Error("expected mutation response to be true but is", mutationResponse.Allowed)
 	}
 
 	var patches []patchOperation
 	err = json.Unmarshal(mutationResponse.Patch, &patches)
 	if len(patches) != 0 {
-		t.Errorf("expected number of patches to be 0 but is %v", len(patches))
+		t.Error("expected number of patches to be 0 but is", len(patches))
 	}
 
 	t.Log(patches)
 
 	mutatedPod, err := patchPodRaw(*pod, mutationResponse.Patch)
 	if err != nil {
-		t.Errorf("failed to apply patches: %+v", err)
+		t.Error("failed to apply patches:", err)
 	}
 
 	validationResponse := karydiaAdmission.Admit(ar, false)
 	if !validationResponse.Allowed {
-		t.Errorf("expected validation response to be true but is %v", validationResponse.Allowed)
+		t.Error("expected validation response to be true but is", validationResponse.Allowed)
 	}
 
 	ar.Request.Object.Raw, _ = json.Marshal(mutatedPod)
 
 	validationResponse = karydiaAdmission.Admit(ar, false)
 	if !validationResponse.Allowed {
-		t.Errorf("expected validation response to be true but is %v", validationResponse.Allowed)
+		t.Error("expected validation response to be true but is", validationResponse.Allowed)
 	}
 
 }
@@ -286,7 +286,7 @@ func TestPodCorrectSeccomp(t *testing.T) {
 		KubeClientset: kubeclient,
 	})
 	if err != nil {
-		t.Fatalf("Failed to load karydia admission: %v\n", err)
+		t.Fatal("Failed to load karydia admission:", err)
 	}
 
 	pod := &corev1.Pod{
@@ -321,18 +321,18 @@ func TestPodCorrectSeccomp(t *testing.T) {
 
 	mutationResponse := karydiaAdmission.Admit(ar, true)
 	if !mutationResponse.Allowed {
-		t.Errorf("expected mutation response to be true but is %v", mutationResponse.Allowed)
+		t.Error("expected mutation response to be true but is", mutationResponse.Allowed)
 	}
 
 	var patches []patchOperation
 	err = json.Unmarshal(mutationResponse.Patch, &patches)
 	if len(patches) != 0 {
-		t.Errorf("expected number of patches to be 0 but is %v", len(patches))
+		t.Error("expected number of patches to be 0 but is", len(patches))
 	}
 
 	validationResponse := karydiaAdmission.Admit(ar, false)
 	if !validationResponse.Allowed {
-		t.Errorf("expected validation response to be true but is %v", mutationResponse.Allowed)
+		t.Error("expected validation response to be true but is", mutationResponse.Allowed)
 	}
 }
 
@@ -352,7 +352,7 @@ func TestServiceAccountPlain(t *testing.T) {
 		KubeClientset: kubeclient,
 	})
 	if err != nil {
-		t.Fatalf("Failed to load karydia admission: %v\n", err)
+		t.Fatal("Failed to load karydia admission:", err)
 	}
 
 	servieAccount := &corev1.ServiceAccount{
@@ -378,30 +378,30 @@ func TestServiceAccountPlain(t *testing.T) {
 
 	mutationResponse := karydiaAdmission.Admit(ar, true)
 	if !mutationResponse.Allowed {
-		t.Errorf("expected mutation response to be true but is %v", mutationResponse.Allowed)
+		t.Error("expected mutation response to be true but is", mutationResponse.Allowed)
 	}
 
 	var patches []patchOperation
 	err = json.Unmarshal(mutationResponse.Patch, &patches)
 	if len(patches) != 2 {
-		t.Errorf("expected number of patches to be 2 but is %v", len(patches))
+		t.Error("expected number of patches to be 2 but is", len(patches))
 	}
 
 	mutatedServiceAccount, err := patchServiceAccountRaw(*servieAccount, mutationResponse.Patch)
 	if err != nil {
-		t.Errorf("failed to apply patches: %+v", err)
+		t.Error("failed to apply patches:", err)
 	}
 
 	validationResponse := karydiaAdmission.Admit(ar, false)
 	if validationResponse.Allowed {
-		t.Errorf("expected validation response to be false but is %v", mutationResponse.Allowed)
+		t.Error("expected validation response to be false but is", mutationResponse.Allowed)
 	}
 
 	ar.Request.Object.Raw, _ = json.Marshal(mutatedServiceAccount)
 
 	validationResponse = karydiaAdmission.Admit(ar, false)
 	if !validationResponse.Allowed {
-		t.Errorf("expected validation response to be true but is %v", mutationResponse.Allowed)
+		t.Error("expected validation response to be true but is", mutationResponse.Allowed)
 	}
 
 }
@@ -422,7 +422,7 @@ func TestServiceAccountAutomountDefined(t *testing.T) {
 		KubeClientset: kubeclient,
 	})
 	if err != nil {
-		t.Fatalf("Failed to load karydia admission: %v\n", err)
+		t.Fatal("Failed to load karydia admission:", err)
 	}
 
 	var vTrue = true
@@ -451,30 +451,30 @@ func TestServiceAccountAutomountDefined(t *testing.T) {
 
 	mutationResponse := karydiaAdmission.Admit(ar, true)
 	if !mutationResponse.Allowed {
-		t.Errorf("expected mutation response to be true but is %v", mutationResponse.Allowed)
+		t.Error("expected mutation response to be true but is", mutationResponse.Allowed)
 	}
 
 	var patches []patchOperation
 	err = json.Unmarshal(mutationResponse.Patch, &patches)
 	if len(patches) != 0 {
-		t.Errorf("expected number of patches to be 0 but is %v", len(patches))
+		t.Error("expected number of patches to be 0 but is", len(patches))
 	}
 
 	mutatedServiceAccount, err := patchServiceAccountRaw(*servieAccount, mutationResponse.Patch)
 	if err != nil {
-		t.Errorf("failed to apply patches: %+v", err)
+		t.Error("failed to apply patches:", err)
 	}
 
 	validationResponse := karydiaAdmission.Admit(ar, false)
 	if !validationResponse.Allowed {
-		t.Errorf("expected validation response to be true but is %v", mutationResponse.Allowed)
+		t.Error("expected validation response to be true but is", mutationResponse.Allowed)
 	}
 
 	ar.Request.Object.Raw, _ = json.Marshal(mutatedServiceAccount)
 
 	validationResponse = karydiaAdmission.Admit(ar, false)
 	if !validationResponse.Allowed {
-		t.Errorf("expected validation response to be true but is %v", mutationResponse.Allowed)
+		t.Error("expected validation response to be true but is", mutationResponse.Allowed)
 	}
 
 }
@@ -495,7 +495,7 @@ func TestServiceAccountDefault(t *testing.T) {
 		KubeClientset: kubeclient,
 	})
 	if err != nil {
-		t.Fatalf("Failed to load karydia admission: %v\n", err)
+		t.Fatal("Failed to load karydia admission:", err)
 	}
 
 	servieAccount := &corev1.ServiceAccount{
@@ -521,30 +521,30 @@ func TestServiceAccountDefault(t *testing.T) {
 
 	mutationResponse := karydiaAdmission.Admit(ar, true)
 	if !mutationResponse.Allowed {
-		t.Errorf("expected mutation response to be true but is %v", mutationResponse.Allowed)
+		t.Error("expected mutation response to be true but is", mutationResponse.Allowed)
 	}
 
 	var patches []patchOperation
 	err = json.Unmarshal(mutationResponse.Patch, &patches)
 	if len(patches) != 2 {
-		t.Errorf("expected number of patches to be 2 but is %v", len(patches))
+		t.Error("expected number of patches to be 2 but is", len(patches))
 	}
 
 	mutatedServiceAccount, err := patchServiceAccountRaw(*servieAccount, mutationResponse.Patch)
 	if err != nil {
-		t.Errorf("failed to apply patches: %+v", err)
+		t.Error("failed to apply patches:", err)
 	}
 
 	validationResponse := karydiaAdmission.Admit(ar, false)
 	if validationResponse.Allowed {
-		t.Errorf("expected validation response to be false but is %v", mutationResponse.Allowed)
+		t.Error("expected validation response to be false but is", mutationResponse.Allowed)
 	}
 
 	ar.Request.Object.Raw, _ = json.Marshal(mutatedServiceAccount)
 
 	validationResponse = karydiaAdmission.Admit(ar, false)
 	if !validationResponse.Allowed {
-		t.Errorf("expected validation response to be true but is %v", mutationResponse.Allowed)
+		t.Error("expected validation response to be true but is", mutationResponse.Allowed)
 	}
 
 }
@@ -556,7 +556,7 @@ func TestInvalidAdmissionReview(t *testing.T) {
 		KubeClientset: kubeclient,
 	})
 	if err != nil {
-		t.Fatalf("Failed to load karydia admission: %v\n", err)
+		t.Fatal("Failed to load karydia admission:", err)
 	}
 
 	/* DELETE operation -> is currently ignored */
@@ -570,12 +570,12 @@ func TestInvalidAdmissionReview(t *testing.T) {
 
 	mutationResponse := karydiaAdmission.Admit(ar, true)
 	if !mutationResponse.Allowed {
-		t.Errorf("expected mutation response to be true but is %v", mutationResponse.Allowed)
+		t.Error("expected mutation response to be true but is", mutationResponse.Allowed)
 	}
 
 	validationResponse := karydiaAdmission.Admit(ar, false)
 	if !validationResponse.Allowed {
-		t.Errorf("expected validation response to be true but is %v", mutationResponse.Allowed)
+		t.Error("expected validation response to be true but is", mutationResponse.Allowed)
 	}
 
 	/* Ignored resource type */
@@ -589,12 +589,12 @@ func TestInvalidAdmissionReview(t *testing.T) {
 
 	mutationResponse = karydiaAdmission.Admit(ar, true)
 	if !mutationResponse.Allowed {
-		t.Errorf("expected mutation response to be true but is %v", mutationResponse.Allowed)
+		t.Error("expected mutation response to be true but is", mutationResponse.Allowed)
 	}
 
 	validationResponse = karydiaAdmission.Admit(ar, false)
 	if !validationResponse.Allowed {
-		t.Errorf("expected validation response to be true but is %v", mutationResponse.Allowed)
+		t.Error("expected validation response to be true but is", mutationResponse.Allowed)
 	}
 
 	/* Unknown namepsace ServiceAccount */
@@ -608,12 +608,12 @@ func TestInvalidAdmissionReview(t *testing.T) {
 
 	mutationResponse = karydiaAdmission.Admit(ar, true)
 	if mutationResponse.Allowed {
-		t.Errorf("expected mutation response to be false but is %v", mutationResponse.Allowed)
+		t.Error("expected mutation response to be false but is", mutationResponse.Allowed)
 	}
 
 	validationResponse = karydiaAdmission.Admit(ar, false)
 	if validationResponse.Allowed {
-		t.Errorf("expected validation response to be false but is %v", mutationResponse.Allowed)
+		t.Error("expected validation response to be false but is", mutationResponse.Allowed)
 	}
 
 	/* Unknown namepsace Pod */
@@ -627,12 +627,12 @@ func TestInvalidAdmissionReview(t *testing.T) {
 
 	mutationResponse = karydiaAdmission.Admit(ar, true)
 	if mutationResponse.Allowed {
-		t.Errorf("expected mutation response to be false but is %v", mutationResponse.Allowed)
+		t.Error("expected mutation response to be false but is", mutationResponse.Allowed)
 	}
 
 	validationResponse = karydiaAdmission.Admit(ar, false)
 	if validationResponse.Allowed {
-		t.Errorf("expected validation response to be false but is %v", mutationResponse.Allowed)
+		t.Error("expected validation response to be false but is", mutationResponse.Allowed)
 	}
 
 	/* Missing namepsace */
@@ -645,12 +645,12 @@ func TestInvalidAdmissionReview(t *testing.T) {
 
 	mutationResponse = karydiaAdmission.Admit(ar, true)
 	if mutationResponse.Allowed {
-		t.Errorf("expected mutation response to be false but is %v", mutationResponse.Allowed)
+		t.Error("expected mutation response to be false but is", mutationResponse.Allowed)
 	}
 
 	validationResponse = karydiaAdmission.Admit(ar, false)
 	if validationResponse.Allowed {
-		t.Errorf("expected validation response to be false but is %v", mutationResponse.Allowed)
+		t.Error("expected validation response to be false but is", mutationResponse.Allowed)
 	}
 }
 
@@ -670,7 +670,7 @@ func TestInvalidDecodeOfResources(t *testing.T) {
 		KubeClientset: kubeclient,
 	})
 	if err != nil {
-		t.Fatalf("Failed to load karydia admission: %v\n", err)
+		t.Fatal("Failed to load karydia admission:", err)
 	}
 
 	invalidRawServiceAccount := make([]byte, 4)
@@ -688,7 +688,7 @@ func TestInvalidDecodeOfResources(t *testing.T) {
 
 	mutationResponse := karydiaAdmission.Admit(ar, true)
 	if mutationResponse.Allowed {
-		t.Errorf("expected mutation response to be false but is %v", mutationResponse.Allowed)
+		t.Error("expected mutation response to be false but is", mutationResponse.Allowed)
 	}
 
 	ar = v1beta1.AdmissionReview{
@@ -704,7 +704,7 @@ func TestInvalidDecodeOfResources(t *testing.T) {
 
 	mutationResponse = karydiaAdmission.Admit(ar, true)
 	if mutationResponse.Allowed {
-		t.Errorf("expected mutation response to be false but is %v", mutationResponse.Allowed)
+		t.Error("expected mutation response to be false but is", mutationResponse.Allowed)
 	}
 }
 

--- a/pkg/admission/karydia/seccomp_test.go
+++ b/pkg/admission/karydia/seccomp_test.go
@@ -38,22 +38,22 @@ func TestPodSeccompDefaultProfileWithAnnotation(t *testing.T) {
 
 	patches = mutatePodSeccompProfile(pod, setting, patches)
 	if len(patches.operations) != 0 {
-		t.Errorf("expected 0 patches but got: %+v", patches.operations)
+		t.Error("expected 0 patches but got:", patches.operations)
 	}
 	mutatedPod, err := patchPod(pod, patches)
 	if err != nil {
-		t.Errorf("failed to apply patches: %+v", err)
+		t.Error("failed to apply patches:", err)
 	}
 	// Zero validation errors expected for mutated pod
 	validationErrors = validatePodSeccompProfile(mutatedPod, setting, validationErrors)
 	if len(validationErrors) != 0 {
-		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
+		t.Error("expected 0 validationErrors but got:", validationErrors)
 	}
 	validationErrors = []string{}
 	// Zero validation error expected for initial pod
 	validationErrors = validatePodSeccompProfile(pod, setting, validationErrors)
 	if len(validationErrors) != 0 {
-		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
+		t.Error("expected 0 validationErrors but got:", validationErrors)
 	}
 }
 
@@ -66,27 +66,27 @@ func TestPodSeccompDefaultProfileNoAnnotation(t *testing.T) {
 
 	patches = mutatePodSeccompProfile(pod, setting, patches)
 	if len(patches.operations) != 2 {
-		t.Errorf("expected 2 patches but got: %+v", patches.operations)
+		t.Error("expected 2 patches but got:", patches.operations)
 	}
 
 	t.Log(patches)
 
 	mutatedPod, err := patchPod(pod, patches)
 	if err != nil {
-		t.Errorf("failed to apply patches: %+v", err)
+		t.Error("failed to apply patches:", err)
 	}
 
 	t.Log(mutatedPod)
 	// Zero validation errors expected for mutated pod
 	validationErrors = validatePodSeccompProfile(mutatedPod, setting, validationErrors)
 	if len(validationErrors) != 0 {
-		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
+		t.Error("expected 0 validationErrors but got:", validationErrors)
 	}
 	validationErrors = []string{}
 	// One validation error expected for initial pod
 	validationErrors = validatePodSeccompProfile(pod, setting, validationErrors)
 	if len(validationErrors) != 1 {
-		t.Errorf("expected 1 validationErrors but got: %+v", validationErrors)
+		t.Error("expected 1 validationErrors but got:", validationErrors)
 	}
 }
 
@@ -102,21 +102,21 @@ func TestPodSeccompDefaultProfileOtherAnnotation(t *testing.T) {
 
 	patches = mutatePodSeccompProfile(pod, setting, patches)
 	if len(patches.operations) != 0 {
-		t.Errorf("expected 0 patches but got: %+v", patches.operations)
+		t.Error("expected 0 patches but got:", patches.operations)
 	}
 	mutatedPod, err := patchPod(pod, patches)
 	if err != nil {
-		t.Errorf("failed to apply patches: %+v", err)
+		t.Error("failed to apply patches:", err)
 	}
 	// No validation error expected for mutated pod
 	validationErrors = validatePodSeccompProfile(mutatedPod, setting, validationErrors)
 	if len(validationErrors) != 0 {
-		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
+		t.Error("expected 0 validationErrors but got:", validationErrors)
 	}
 	validationErrors = []string{}
 	// No validation error expected for initial pod
 	validationErrors = validatePodSeccompProfile(pod, setting, validationErrors)
 	if len(validationErrors) != 0 {
-		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
+		t.Error("expected 0 validationErrors but got:", validationErrors)
 	}
 }

--- a/pkg/admission/karydia/service_token_test.go
+++ b/pkg/admission/karydia/service_token_test.go
@@ -39,22 +39,22 @@ func TestServiceAccountChangeDefaultAnnotationDefaultServiceAccountMountUndefine
 	setting := Setting{value: "change-default", src: "namespace"}
 	patches = mutateServiceAccountTokenMount(sAcc, setting, patches)
 	if len(patches.operations) != 2 {
-		t.Errorf("expected 2 patches but got: %+v", patches.operations)
+		t.Error("expected 2 patches but got:", patches.operations)
 	}
 	mutatedServiceAccount, err := patchServiceAccount(sAcc, patches)
 	if err != nil {
-		t.Errorf("failed to apply patches: %+v", err)
+		t.Error("failed to apply patches:", err)
 	}
 	// Zero validation errors expected for mutated pod
 	validationErrors = validateServiceAccountTokenMount(mutatedServiceAccount, setting, validationErrors)
 	if len(validationErrors) != 0 {
-		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
+		t.Error("expected 0 validationErrors but got:", validationErrors)
 	}
 	validationErrors = []string{}
 	// One validation error expected for initial pod
 	validationErrors = validateServiceAccountTokenMount(sAcc, setting, validationErrors)
 	if len(validationErrors) != 1 {
-		t.Errorf("expected 1 validationErrors but got: %+v", validationErrors)
+		t.Error("expected 1 validationErrors but got:", validationErrors)
 	}
 }
 
@@ -71,22 +71,22 @@ func TestServiceAccountChangeDefaultAnnotationDefaultServiceAccountMountFalse(t 
 
 	patches = mutateServiceAccountTokenMount(sAcc, setting, patches)
 	if len(patches.operations) != 0 {
-		t.Errorf("expected 0 patches but got: %+v", patches.operations)
+		t.Error("expected 0 patches but got:", patches.operations)
 	}
 	mutatedServiceAccount, err := patchServiceAccount(sAcc, patches)
 	if err != nil {
-		t.Errorf("failed to apply patches: %+v", err)
+		t.Error("failed to apply patches:", err)
 	}
 	// Zero validation errors expected for mutated pod
 	validationErrors = validateServiceAccountTokenMount(mutatedServiceAccount, setting, validationErrors)
 	if len(validationErrors) != 0 {
-		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
+		t.Error("expected 0 validationErrors but got:", validationErrors)
 	}
 	validationErrors = []string{}
 	// Zero validation errors expected for mutated pod
 	validationErrors = validateServiceAccountTokenMount(sAcc, setting, validationErrors)
 	if len(validationErrors) != 0 {
-		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
+		t.Error("expected 0 validationErrors but got:", validationErrors)
 	}
 }
 
@@ -103,22 +103,22 @@ func TestServiceAccountChangeDefaultAnnotationDefaultServiceAccountMountTrue(t *
 
 	patches = mutateServiceAccountTokenMount(sAcc, setting, patches)
 	if len(patches.operations) != 0 {
-		t.Errorf("expected 0 patches but got: %+v", patches.operations)
+		t.Error("expected 0 patches but got:", patches.operations)
 	}
 	mutatedServiceAccount, err := patchServiceAccount(sAcc, patches)
 	if err != nil {
-		t.Errorf("failed to apply patches: %+v", err)
+		t.Error("failed to apply patches:", err)
 	}
 	// Zero validation errors expected for mutated pod
 	validationErrors = validateServiceAccountTokenMount(mutatedServiceAccount, setting, validationErrors)
 	if len(validationErrors) != 0 {
-		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
+		t.Error("expected 0 validationErrors but got:", validationErrors)
 	}
 	validationErrors = []string{}
 	// Zero validation errors expected for mutated pod
 	validationErrors = validateServiceAccountTokenMount(sAcc, setting, validationErrors)
 	if len(validationErrors) != 0 {
-		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
+		t.Error("expected 0 validationErrors but got:", validationErrors)
 	}
 }
 
@@ -133,22 +133,22 @@ func TestServiceAccountChangeDefaultAnnotationSpecificServiceAccountMountUndefin
 
 	patches = mutateServiceAccountTokenMount(sAcc, setting, patches)
 	if len(patches.operations) != 0 {
-		t.Errorf("expected 0 patches but got: %+v", patches.operations)
+		t.Error("expected 0 patches but got:", patches.operations)
 	}
 	mutatedServiceAccount, err := patchServiceAccount(sAcc, patches)
 	if err != nil {
-		t.Errorf("failed to apply patches: %+v", err)
+		t.Error("failed to apply patches:", err)
 	}
 	// Zero validation errors expected for mutated pod
 	validationErrors = validateServiceAccountTokenMount(mutatedServiceAccount, setting, validationErrors)
 	if len(validationErrors) != 0 {
-		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
+		t.Error("expected 0 validationErrors but got:", validationErrors)
 	}
 	validationErrors = []string{}
 	// Zero validation errors expected for mutated pod
 	validationErrors = validateServiceAccountTokenMount(sAcc, setting, validationErrors)
 	if len(validationErrors) != 0 {
-		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
+		t.Error("expected 0 validationErrors but got:", validationErrors)
 	}
 }
 func TestServiceAccountRandomAnnotationDefaultServiceAccountMountUndefined(t *testing.T) {
@@ -162,22 +162,22 @@ func TestServiceAccountRandomAnnotationDefaultServiceAccountMountUndefined(t *te
 
 	patches = mutateServiceAccountTokenMount(sAcc, setting, patches)
 	if len(patches.operations) != 0 {
-		t.Errorf("expected 0 patches but got: %+v", patches.operations)
+		t.Error("expected 0 patches but got:", patches.operations)
 	}
 	mutatedServiceAccount, err := patchServiceAccount(sAcc, patches)
 	if err != nil {
-		t.Errorf("failed to apply patches: %+v", err)
+		t.Error("failed to apply patches:", err)
 	}
 	// Zero validation errors expected for mutated pod
 	validationErrors = validateServiceAccountTokenMount(mutatedServiceAccount, setting, validationErrors)
 	if len(validationErrors) != 0 {
-		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
+		t.Error("expected 0 validationErrors but got:", validationErrors)
 	}
 	validationErrors = []string{}
 	// Zero validation errors expected for mutated pod
 	validationErrors = validateServiceAccountTokenMount(sAcc, setting, validationErrors)
 	if len(validationErrors) != 0 {
-		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
+		t.Error("expected 0 validationErrors but got:", validationErrors)
 	}
 }
 
@@ -197,22 +197,22 @@ func TestServiceAccountChangeAllAnnotationDefaultServiceAccountMountUndefined(t 
 
 	patches = mutateServiceAccountTokenMount(sAcc, setting, patches)
 	if len(patches.operations) != 2 {
-		t.Errorf("expected 2 patches but got: %+v", patches.operations)
+		t.Error("expected 2 patches but got:", patches.operations)
 	}
 	mutatedServiceAccount, err := patchServiceAccount(sAcc, patches)
 	if err != nil {
-		t.Errorf("failed to apply patches: %+v", err)
+		t.Error("failed to apply patches:", err)
 	}
 	// Zero validation errors expected for mutated pod
 	validationErrors = validateServiceAccountTokenMount(mutatedServiceAccount, setting, validationErrors)
 	if len(validationErrors) != 0 {
-		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
+		t.Error("expected 0 validationErrors but got:", validationErrors)
 	}
 	validationErrors = []string{}
 	// One validation error expected for initial pod
 	validationErrors = validateServiceAccountTokenMount(sAcc, setting, validationErrors)
 	if len(validationErrors) != 1 {
-		t.Errorf("expected 1 validationErrors but got: %+v", validationErrors)
+		t.Error("expected 1 validationErrors but got:", validationErrors)
 	}
 }
 
@@ -227,22 +227,22 @@ func TestServiceAccountChangeAllAnnotationSpecificServiceAccountMountUndefined(t
 
 	patches = mutateServiceAccountTokenMount(sAcc, setting, patches)
 	if len(patches.operations) != 2 {
-		t.Errorf("expected 2 patches but got: %+v", patches.operations)
+		t.Error("expected 2 patches but got:", patches.operations)
 	}
 	mutatedServiceAccount, err := patchServiceAccount(sAcc, patches)
 	if err != nil {
-		t.Errorf("failed to apply patches: %+v", err)
+		t.Error("failed to apply patches:", err)
 	}
 	// Zero validation errors expected for mutated pod
 	validationErrors = validateServiceAccountTokenMount(mutatedServiceAccount, setting, validationErrors)
 	if len(validationErrors) != 0 {
-		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
+		t.Error("expected 0 validationErrors but got:", validationErrors)
 	}
 	validationErrors = []string{}
 	// One validation error expected for initial pod
 	validationErrors = validateServiceAccountTokenMount(sAcc, setting, validationErrors)
 	if len(validationErrors) != 1 {
-		t.Errorf("expected 1 validationErrors but got: %+v", validationErrors)
+		t.Error("expected 1 validationErrors but got:", validationErrors)
 	}
 }
 
@@ -259,22 +259,22 @@ func TestServiceAccountChangeAllAnnotationSpecificServiceAccountMountFalse(t *te
 
 	patches = mutateServiceAccountTokenMount(sAcc, setting, patches)
 	if len(patches.operations) != 0 {
-		t.Errorf("expected 0 patches but got: %+v", patches.operations)
+		t.Error("expected 0 patches but got:", patches.operations)
 	}
 	mutatedServiceAccount, err := patchServiceAccount(sAcc, patches)
 	if err != nil {
-		t.Errorf("failed to apply patches: %+v", err)
+		t.Error("failed to apply patches:", err)
 	}
 	// Zero validation errors expected for mutated pod
 	validationErrors = validateServiceAccountTokenMount(mutatedServiceAccount, setting, validationErrors)
 	if len(validationErrors) != 0 {
-		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
+		t.Error("expected 0 validationErrors but got:", validationErrors)
 	}
 	validationErrors = []string{}
 	// Zero validation errors expected for mutated pod
 	validationErrors = validateServiceAccountTokenMount(sAcc, setting, validationErrors)
 	if len(validationErrors) != 0 {
-		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
+		t.Error("expected 0 validationErrors but got:", validationErrors)
 	}
 }
 
@@ -291,22 +291,22 @@ func TestServiceAccountChangeAllAnnotationspecificServiceAccountMountTrue(t *tes
 
 	patches = mutateServiceAccountTokenMount(sAcc, setting, patches)
 	if len(patches.operations) != 0 {
-		t.Errorf("expected 0 patches but got: %+v", patches.operations)
+		t.Error("expected 0 patches but got:", patches.operations)
 	}
 	mutatedServiceAccount, err := patchServiceAccount(sAcc, patches)
 	if err != nil {
-		t.Errorf("failed to apply patches: %+v", err)
+		t.Error("failed to apply patches:", err)
 	}
 	// Zero validation errors expected for mutated pod
 	validationErrors = validateServiceAccountTokenMount(mutatedServiceAccount, setting, validationErrors)
 	if len(validationErrors) != 0 {
-		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
+		t.Error("expected 0 validationErrors but got:", validationErrors)
 	}
 	validationErrors = []string{}
 	// Zero validation errors expected for mutated pod
 	validationErrors = validateServiceAccountTokenMount(sAcc, setting, validationErrors)
 	if len(validationErrors) != 0 {
-		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
+		t.Error("expected 0 validationErrors but got:", validationErrors)
 	}
 }
 
@@ -321,22 +321,22 @@ func TestServiceAccountRandomAnnotationSpecificServiceAccountMountUndefined(t *t
 
 	patches = mutateServiceAccountTokenMount(sAcc, setting, patches)
 	if len(patches.operations) != 0 {
-		t.Errorf("expected 0 patches but got: %+v", patches.operations)
+		t.Error("expected 0 patches but got:", patches.operations)
 	}
 	mutatedServiceAccount, err := patchServiceAccount(sAcc, patches)
 	if err != nil {
-		t.Errorf("failed to apply patches: %+v", err)
+		t.Error("failed to apply patches:", err)
 	}
 	// Zero validation errors expected for mutated pod
 	validationErrors = validateServiceAccountTokenMount(mutatedServiceAccount, setting, validationErrors)
 	if len(validationErrors) != 0 {
-		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
+		t.Error("expected 0 validationErrors but got:", validationErrors)
 	}
 	validationErrors = []string{}
 	// Zero validation errors expected for mutated pod
 	validationErrors = validateServiceAccountTokenMount(sAcc, setting, validationErrors)
 	if len(validationErrors) != 0 {
-		t.Errorf("expected 0 validationErrors but got: %+v", validationErrors)
+		t.Error("expected 0 validationErrors but got:", validationErrors)
 	}
 }
 

--- a/pkg/apis/karydia/register.go
+++ b/pkg/apis/karydia/register.go
@@ -1,4 +1,6 @@
-// Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+// Copyright (C) 2019 SAP SE or an SAP affiliate company. All rights reserved.
+// This file is licensed under the Apache Software License, v. 2 except as
+// noted otherwise in the LICENSE file.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/controller/config_reconciler.go
+++ b/pkg/controller/config_reconciler.go
@@ -58,7 +58,7 @@ func NewConfigReconciler(
 	karydiaConfigInformer v1alpha12.KarydiaConfigInformer,
 ) *ConfigReconciler {
 	reconciler := &ConfigReconciler{
-		log:         logger.NewComponentLogger("config_reconciler"),
+		log:         logger.NewComponentLogger(logger.GetCallersFilename()),
 		config:      karydiaConfig,
 		controllers: karydiaControllers,
 		clientset:   karydiaClientset,
@@ -185,13 +185,13 @@ func (reconciler *ConfigReconciler) syncConfigHandler(key string) error {
 	// convert namespace/name string into distinct (namespace and) name
 	_, configName, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
-		reconciler.log.Errorf("invalid resource key: %s", key)
+		reconciler.log.Errorln("invalid resource key:", key)
 		return nil
 	}
 
 	// if no global config is set Forget this item
 	if reconciler.config.Name == "" {
-		reconciler.log.Errorf("No config set")
+		reconciler.log.Errorln("No config set")
 		return nil
 	}
 
@@ -205,19 +205,19 @@ func (reconciler *ConfigReconciler) syncConfigHandler(key string) error {
 			if errors.IsNotFound(err) {
 				reconciler.log.Errorf("karydia config '%s' no longer exists", key)
 				if err := reconciler.createConfig(); err != nil {
-					reconciler.log.Errorf("failed to recreate karydia config: %v", err)
+					reconciler.log.Errorln("failed to recreate karydia config:", err)
 					return err
 				}
 				return nil
 			}
 			return err
 		} else {
-			reconciler.log.Infof("Found karydia config %s", config.Name)
+			reconciler.log.Infoln("Found karydia config", config.Name)
 			// compare new config with the one in memory
 			if reconciler.reconcileIsNeeded(*config) {
 				// update config in memory with new one
 				if err := reconciler.UpdateConfig(*config); err != nil {
-					reconciler.log.Errorf("failed to update karydia config: %v", err)
+					reconciler.log.Errorln("failed to update karydia config:", err)
 					return err
 				}
 			}
@@ -256,11 +256,11 @@ func (reconciler *ConfigReconciler) UpdateConfig(karydiaConfig v1alpha1.KarydiaC
 			return err
 		}
 	}
-	reconciler.log.Infof("KarydiaConfig Name: %s\n", karydiaConfig.Name)
-	reconciler.log.Infof("KarydiaConfig AutomountServiceAccountToken: %s\n", karydiaConfig.Spec.AutomountServiceAccountToken)
-	reconciler.log.Infof("KarydiaConfig SeccompProfile: %s\n", karydiaConfig.Spec.SeccompProfile)
-	reconciler.log.Infof("KarydiaConfig NetworkPolicy: %s\n", karydiaConfig.Spec.NetworkPolicy)
-	reconciler.log.Infof("KarydiaConfig PodSecurityContext: %s\n", karydiaConfig.Spec.PodSecurityContext)
+	reconciler.log.Infoln("KarydiaConfig Name:", karydiaConfig.Name)
+	reconciler.log.Infoln("KarydiaConfig AutomountServiceAccountToken:", karydiaConfig.Spec.AutomountServiceAccountToken)
+	reconciler.log.Infoln("KarydiaConfig SeccompProfile:", karydiaConfig.Spec.SeccompProfile)
+	reconciler.log.Infoln("KarydiaConfig NetworkPolicy:", karydiaConfig.Spec.NetworkPolicy)
+	reconciler.log.Infoln("KarydiaConfig PodSecurityContext:", karydiaConfig.Spec.PodSecurityContext)
 	return nil
 }
 

--- a/pkg/controller/networkpolicy_reconciler.go
+++ b/pkg/controller/networkpolicy_reconciler.go
@@ -18,8 +18,8 @@ package controller
 
 import (
 	"bytes"
-	"flag"
 	"fmt"
+	"github.com/karydia/karydia/pkg/logger"
 	"time"
 
 	"github.com/karydia/karydia/pkg/apis/karydia/v1alpha1"
@@ -30,7 +30,6 @@ import (
 	v1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	namespaceInformer "k8s.io/client-go/informers/core/v1"
 	networkpolicyInformer "k8s.io/client-go/informers/networking/v1"
@@ -39,12 +38,12 @@ import (
 	kubelistersNetworkingv1 "k8s.io/client-go/listers/networking/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
-	"k8s.io/klog"
 )
 
 const controllerAgentName = "networkpolicy_reconciler"
 
 type NetworkpolicyReconciler struct {
+	log                          *logger.Logger
 	defaultNetworkPolicyName     string
 	defaultNetworkPolicies       map[string]*networkingv1.NetworkPolicy
 	defaultNetworkPolicyExcludes []string
@@ -71,6 +70,7 @@ func NewNetworkpolicyReconciler(
 	defaultNetworkPolicies map[string]*networkingv1.NetworkPolicy, defaultNetworkPolicyName string, defaultNetworkPolicyExcludes []string) *NetworkpolicyReconciler {
 
 	reconciler := &NetworkpolicyReconciler{
+		log:                          logger.NewComponentLogger("networkpolicy_reconciler"),
 		defaultNetworkPolicyName:     defaultNetworkPolicyName,
 		kubeclientset:                kubeclientset,
 		karydiaClientset:             karydiaClientset,
@@ -84,10 +84,7 @@ func NewNetworkpolicyReconciler(
 		defaultNetworkPolicyExcludes: defaultNetworkPolicyExcludes,
 	}
 
-	klogFlags := flag.NewFlagSet("v", 0)
-	klog.InitFlags(klogFlags)
-
-	klog.Info("Setting up event handlers")
+	reconciler.log.Infoln("Setting up event handlers")
 	networkpolicyInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		UpdateFunc: func(old, new interface{}) {
 			newNetworkPolicy := new.(*networkingv1.NetworkPolicy)
@@ -108,26 +105,26 @@ func NewNetworkpolicyReconciler(
 }
 
 func (reconciler *NetworkpolicyReconciler) Run(threadiness int, stopCh <-chan struct{}) error {
-	defer utilruntime.HandleCrash()
+	defer reconciler.log.HandleCrash()
 	defer reconciler.networkPolicyworkqueue.ShutDown()
 	defer reconciler.namespaceWorkqueue.ShutDown()
 
-	klog.Info("Starting karydia network policy reconciler")
-	klog.Info("Waiting for informer caches to sync")
+	reconciler.log.Infoln("Starting karydia network policy reconciler")
+	reconciler.log.Infoln("Waiting for informer caches to sync")
 	if ok := cache.WaitForCacheSync(stopCh, reconciler.networkPoliciesSynced, reconciler.namespacesSynced); !ok {
 		return fmt.Errorf("failed to wait for caches to sync")
 	}
 
-	klog.Info("Starting workers")
+	reconciler.log.Infoln("Starting workers")
 
 	for i := 0; i < threadiness; i++ {
 		go wait.Until(reconciler.runNetworkPolicyWorker, time.Second, stopCh)
 		go wait.Until(reconciler.runNamespaceWorker, time.Second, stopCh)
 	}
 
-	klog.Info("Started workers")
+	reconciler.log.Infoln("Started workers")
 	<-stopCh
-	klog.Info("Shutting down workers")
+	reconciler.log.Infoln("Shutting down workers")
 
 	return nil
 }
@@ -155,7 +152,7 @@ func (reconciler *NetworkpolicyReconciler) processNextNetworkPolicyWorkItem() bo
 
 		if key, ok = obj.(string); !ok {
 			reconciler.networkPolicyworkqueue.Forget(obj)
-			utilruntime.HandleError(fmt.Errorf("expected string in workqueue but got %#v", obj))
+			reconciler.log.Errorf("expected string in workqueue but got %#v", obj)
 			return nil
 		}
 
@@ -165,12 +162,12 @@ func (reconciler *NetworkpolicyReconciler) processNextNetworkPolicyWorkItem() bo
 		}
 
 		reconciler.networkPolicyworkqueue.Forget(obj)
-		klog.Infof("Successfully synced network policy '%s'", key)
+		reconciler.log.Infof("Successfully synced network policy '%s'", key)
 		return nil
 	}(obj)
 
 	if err != nil {
-		utilruntime.HandleError(err)
+		reconciler.log.Errorln(err)
 		return true
 	}
 
@@ -192,7 +189,7 @@ func (reconciler *NetworkpolicyReconciler) processNextNamespaceWorkItem() bool {
 		if key, ok = obj.(string); !ok {
 
 			reconciler.namespaceWorkqueue.Forget(obj)
-			utilruntime.HandleError(fmt.Errorf("expected string in workqueue but got %#v", obj))
+			reconciler.log.Errorf("expected string in workqueue but got %#v", obj)
 			return nil
 		}
 
@@ -202,12 +199,12 @@ func (reconciler *NetworkpolicyReconciler) processNextNamespaceWorkItem() bool {
 		}
 
 		reconciler.namespaceWorkqueue.Forget(obj)
-		klog.Infof("Successfully synced workitem '%s'", key)
+		reconciler.log.Infof("Successfully synced workitem '%s'", key)
 		return nil
 	}(obj)
 
 	if err != nil {
-		utilruntime.HandleError(err)
+		reconciler.log.Errorln(err)
 		return true
 	}
 
@@ -215,28 +212,28 @@ func (reconciler *NetworkpolicyReconciler) processNextNamespaceWorkItem() bool {
 }
 
 func (reconciler *NetworkpolicyReconciler) syncNetworkPolicyHandler(key string) error {
-	klog.Infof("Start network policy reconciler (syncNetworkPolicyHandler) for %s", key)
+	reconciler.log.Infof("Start network policy reconciler (syncNetworkPolicyHandler) for %s", key)
 	namespaceName, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("invalid resource key: %s", key))
+		reconciler.log.Errorf("invalid resource key: %s", key)
 		return nil
 	}
 	namespace, err := reconciler.kubeclientset.CoreV1().Namespaces().Get(namespaceName, meta_v1.GetOptions{})
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("namespace '%s'does not exist", namespaceName))
+		reconciler.log.Errorf("namespace '%s'does not exist", namespaceName)
 		return nil
 	}
 
 	npName, err := reconciler.getDefaultNetworkpolicyName(namespace)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("error getting default network policy: %s", err))
+		reconciler.log.Errorf("error getting default network policy: %s", err)
 		return nil
 	}
 
 	if _, ok := reconciler.defaultNetworkPolicies[npName]; !ok {
 		if err := reconciler.updateBuffer(npName); err != nil {
 
-			klog.Warningf("Failed to get default network policy %s", npName)
+			reconciler.log.Warnf("Failed to get default network policy %s", npName)
 			return nil
 		}
 	}
@@ -245,19 +242,19 @@ func (reconciler *NetworkpolicyReconciler) syncNetworkPolicyHandler(key string) 
 		networkPolicy, err := reconciler.networkPolicyLister.NetworkPolicies(namespaceName).Get(name)
 		if err != nil {
 			if errors.IsNotFound(err) {
-				utilruntime.HandleError(fmt.Errorf("networkpolicy '%s' in work queue no longer exists", key))
+				reconciler.log.Errorf("networkpolicy '%s' in work queue no longer exists", key)
 				if err := reconciler.createDefaultNetworkPolicy(namespaceName, name); err != nil {
-					klog.Errorf("failed to recreate default network policy: %v", err)
+					reconciler.log.Errorf("failed to recreate default network policy: %v", err)
 					return fmt.Errorf("error syncing %q: %v", namespaceName, err)
 				}
 				return nil
 			}
 			return err
 		} else {
-			klog.Infof("Found networkpolicy %s", key)
+			reconciler.log.Infof("Found networkpolicy %s", key)
 			if reconciler.reconcileIsNeeded(networkPolicy, name) {
 				if err := reconciler.updateDefaultNetworkPolicy(namespaceName, name); err != nil {
-					klog.Errorf("failed to update default network policy: %v", err)
+					reconciler.log.Errorf("failed to update default network policy: %v", err)
 					return fmt.Errorf("error syncing %q: %v", key, err)
 				}
 			} else if err != nil {
@@ -269,32 +266,32 @@ func (reconciler *NetworkpolicyReconciler) syncNetworkPolicyHandler(key string) 
 }
 
 func (reconciler *NetworkpolicyReconciler) syncNamespaceHandler(key string) error {
-	klog.Infof("Start network policy reconciler for namespace %s", key)
+	reconciler.log.Infof("Start network policy reconciler for namespace %s", key)
 	namespace, err := reconciler.namespacesLister.Get(key)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			utilruntime.HandleError(fmt.Errorf("namespace '%s' in work queue no longer exists", key))
+			reconciler.log.Errorf("namespace '%s' in work queue no longer exists", key)
 			return nil
 		}
 	}
-	klog.Infof("Found namespace %s in queue", key)
+	reconciler.log.Infof("Found namespace %s in queue", key)
 	for _, ns := range reconciler.defaultNetworkPolicyExcludes {
 		if key == ns {
-			klog.Infof("Not creating default network policy in %q - namespace excluded", key)
+			reconciler.log.Infof("Not creating default network policy in %q - namespace excluded", key)
 			return nil
 		}
 	}
 
 	npName, err := reconciler.getDefaultNetworkpolicyName(namespace)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("error getting default network policy: %s", err))
+		reconciler.log.Errorf("error getting default network policy: %s", err)
 		return nil
 	}
 
 	if _, ok := reconciler.defaultNetworkPolicies[npName]; !ok {
 		if err := reconciler.updateBuffer(npName); err != nil {
 
-			klog.Warningf("Failed to get default network policy %s", npName)
+			reconciler.log.Warnf("Failed to get default network policy %s", npName)
 			return nil
 		}
 	}
@@ -303,18 +300,18 @@ func (reconciler *NetworkpolicyReconciler) syncNamespaceHandler(key string) erro
 	if err != nil {
 		if errors.IsNotFound(err) {
 			if err := reconciler.createDefaultNetworkPolicy(key, npName); err != nil {
-				klog.Errorf("failed to create default network policy: %v", err)
+				reconciler.log.Errorf("failed to create default network policy: %v", err)
 				return fmt.Errorf("error syncing %q: %v", key, err)
 			}
-			klog.Infof("Successfully synced namespace %q", key)
+			reconciler.log.Infof("Successfully synced namespace %q", key)
 			return nil
 		}
 		return err
 	} else {
-		klog.Infof("Found networkpolicy %s/%s", key, npName)
+		reconciler.log.Infof("Found networkpolicy %s/%s", key, npName)
 		if reconciler.reconcileIsNeeded(networkPolicy, npName) {
 			if err := reconciler.updateDefaultNetworkPolicy(key, npName); err != nil {
-				klog.Errorf("failed to update default network policy: %v", err)
+				reconciler.log.Errorf("failed to update default network policy: %v", err)
 				return fmt.Errorf("error syncing %q: %v", key, err)
 			}
 		} else if err != nil {
@@ -328,7 +325,7 @@ func (reconciler *NetworkpolicyReconciler) getDefaultNetworkpolicyName(namespace
 
 	npName := reconciler.defaultNetworkPolicyName
 	if defaultNetworkPolicyAnnotation, ok := namespace.ObjectMeta.Annotations["karydia.gardener.cloud/networkPolicy"]; ok {
-		klog.Infof("Found annotation, use network policy %q", defaultNetworkPolicyAnnotation)
+		reconciler.log.Infof("Found annotation, use network policy %q", defaultNetworkPolicyAnnotation)
 		npName = defaultNetworkPolicyAnnotation
 	}
 	return npName, err
@@ -338,7 +335,7 @@ func (reconciler *NetworkpolicyReconciler) enqueueNetworkPolicy(obj interface{})
 	var key string
 	var err error
 	if key, err = cache.MetaNamespaceKeyFunc(obj); err != nil {
-		utilruntime.HandleError(err)
+		reconciler.log.Errorln(err)
 		return
 	}
 	reconciler.networkPolicyworkqueue.Add(key)
@@ -347,7 +344,7 @@ func (reconciler *NetworkpolicyReconciler) enqueueNamespace(obj interface{}) {
 	var key string
 	var err error
 	if key, err = cache.MetaNamespaceKeyFunc(obj); err != nil {
-		utilruntime.HandleError(err)
+		reconciler.log.Errorln(err)
 		return
 	}
 	reconciler.namespaceWorkqueue.Add(key)
@@ -377,7 +374,7 @@ func (reconciler *NetworkpolicyReconciler) updateBuffer(networkpolicyName string
 
 	karydiaNetworkPolicy, err := reconciler.karydiaClientset.KarydiaV1alpha1().KarydiaNetworkPolicies().Get(networkpolicyName, meta_v1.GetOptions{})
 	if err != nil {
-		klog.Errorf("Failed to get karydia network policy %s", networkpolicyName)
+		reconciler.log.Errorf("Failed to get karydia network policy %s", networkpolicyName)
 		return fmt.Errorf("Failed to get karydia network policy %s", networkpolicyName)
 	}
 
@@ -385,7 +382,7 @@ func (reconciler *NetworkpolicyReconciler) updateBuffer(networkpolicyName string
 	policy.Name = networkpolicyName
 	policy.Spec = *karydiaNetworkPolicy.Spec.DeepCopy()
 	reconciler.defaultNetworkPolicies[networkpolicyName] = &policy
-	klog.Infof("Network policy %s loaded into buffer. New Buffer length: %v", policy.GetName(), len(reconciler.defaultNetworkPolicies))
+	reconciler.log.Infof("Network policy %s loaded into buffer. New Buffer length: %v", policy.GetName(), len(reconciler.defaultNetworkPolicies))
 
 	return nil
 }
@@ -394,9 +391,9 @@ func (reconciler *NetworkpolicyReconciler) createDefaultNetworkPolicy(namespace 
 
 	desiredPolicy := reconciler.defaultNetworkPolicies[networkpolicyName].DeepCopy()
 	desiredPolicy.ObjectMeta.Namespace = namespace
-	klog.Infof("Deep copy of network policy with name %s", desiredPolicy.GetName())
+	reconciler.log.Infof("Deep copy of network policy with name %s", desiredPolicy.GetName())
 	if _, err := reconciler.kubeclientset.NetworkingV1().NetworkPolicies(namespace).Create(desiredPolicy); err != nil {
-		klog.Errorf("Network policy creation failed. Name specified: %s Actual name %s", networkpolicyName, desiredPolicy.GetName())
+		reconciler.log.Errorf("Network policy creation failed. Name specified: %s Actual name %s", networkpolicyName, desiredPolicy.GetName())
 		return err
 	}
 	return nil

--- a/pkg/controller/networkpolicy_reconciler_test.go
+++ b/pkg/controller/networkpolicy_reconciler_test.go
@@ -1,4 +1,6 @@
-// Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+// Copyright (C) 2019 SAP SE or an SAP affiliate company. All rights reserved.
+// This file is licensed under the Apache Software License, v. 2 except as
+// noted otherwise in the LICENSE file.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -115,7 +117,7 @@ func (f *fixture) runReconcile(networkPolicyName string) {
 
 	err := reconciler.syncNetworkPolicyHandler(networkPolicyName)
 	if err != nil {
-		f.t.Errorf("error syncing networkpolicy: %v", err)
+		f.t.Error("error syncing networkpolicy:", err)
 	}
 }
 
@@ -129,7 +131,7 @@ func (f *fixture) runNamespaceAdd(namespace string) {
 
 	err := reconciler.syncNamespaceHandler(namespace)
 	if err != nil {
-		f.t.Errorf("error syncing foo: %v", err)
+		f.t.Error("error syncing foo:", err)
 	}
 }
 
@@ -196,9 +198,9 @@ func TestReconcileNetworkPolicyUpate(t *testing.T) {
 
 	reconciledPolicy, err := f.kubeclient.NetworkingV1().NetworkPolicies(newNetworkPolicy.Namespace).Get(newNetworkPolicy.Name, meta_v1.GetOptions{})
 	if err != nil {
-		t.Errorf("No error expected")
+		t.Error("No error expected")
 	} else if !networkPoliciesAreEqual(f.defaultNetworkPolicies["karydia-default-network-policy"], reconciledPolicy) {
-		t.Errorf("No reconcilation happened")
+		t.Error("No reconcilation happened")
 	}
 }
 
@@ -216,9 +218,9 @@ func TestReconcileNetworkPolicyDelete(t *testing.T) {
 
 	reconciledPolicy, err := f.kubeclient.NetworkingV1().NetworkPolicies(newNetworkPolicy.Namespace).Get(newNetworkPolicy.Name, meta_v1.GetOptions{})
 	if err != nil {
-		t.Errorf("No error expected")
+		t.Error("No error expected")
 	} else if !networkPoliciesAreEqual(f.defaultNetworkPolicies["karydia-default-network-policy"], reconciledPolicy) {
-		t.Errorf("No reconcilation happened")
+		t.Error("No reconcilation happened")
 	}
 }
 
@@ -236,9 +238,9 @@ func TestReconcileNetworkPolicyWithExisting(t *testing.T) {
 
 	reconciledPolicy, err := f.kubeclient.NetworkingV1().NetworkPolicies(newNetworkPolicy.Namespace).Get(newNetworkPolicy.Name, meta_v1.GetOptions{})
 	if err != nil {
-		t.Errorf("No error expected")
+		t.Error("No error expected")
 	} else if !networkPoliciesAreEqual(f.defaultNetworkPolicies["karydia-default-network-policy"], reconciledPolicy) {
-		t.Errorf("No reconcilation happened")
+		t.Error("No reconcilation happened")
 	}
 
 	f.defaultNetworkPolicies = make(map[string]*networkingv1.NetworkPolicy, 2)
@@ -256,9 +258,9 @@ func TestReconcileNetworkPolicyCreateNamespace(t *testing.T) {
 	f.runNamespaceAdd(newNamespace.Name)
 	reconciledPolicy, err := f.kubeclient.NetworkingV1().NetworkPolicies(newNamespace.Name).Get(f.defaultNetworkPolicies["karydia-default-network-policy"].Name, meta_v1.GetOptions{})
 	if err != nil {
-		t.Errorf("No error expected")
+		t.Error("No error expected")
 	} else if !networkPoliciesAreEqual(f.defaultNetworkPolicies["karydia-default-network-policy"], reconciledPolicy) {
-		t.Errorf("No reconcilation happened")
+		t.Error("No reconcilation happened")
 	}
 }
 
@@ -273,7 +275,7 @@ func TestReconcileNetworkPolicyCreateExcludedNamespace(t *testing.T) {
 	f.runNamespaceAdd(newNamespace.Name)
 	reconciledPolicy, _ := f.kubeclient.NetworkingV1().NetworkPolicies(newNamespace.Name).Get(f.defaultNetworkPolicies["karydia-default-network-policy"].Name, meta_v1.GetOptions{})
 	if reconciledPolicy != nil {
-		t.Errorf("Reconcilation happened - default network policy created for excluded namespace")
+		t.Error("Reconcilation happened - default network policy created for excluded namespace")
 	}
 }
 
@@ -293,13 +295,13 @@ func TestReconcileNetworkPolicyCreateNamespaceWithAnnotation(t *testing.T) {
 
 	reconciledPolicy, err := f.kubeclient.NetworkingV1().NetworkPolicies(newNamespace.Name).Get(f.defaultNetworkPolicies["karydia-default-network-policy"].Name, meta_v1.GetOptions{})
 	if reconciledPolicy != nil {
-		t.Errorf("Default network policy should not be found")
+		t.Error("Default network policy should not be found")
 	}
 
 	reconciledPolicy, err = f.kubeclient.NetworkingV1().NetworkPolicies(newNamespace.Name).Get(f.defaultNetworkPolicies["karydia-default-network-policy-l2"].Name, meta_v1.GetOptions{})
 	if err != nil {
-		t.Errorf("No error expected")
+		t.Error("No error expected")
 	} else if !networkPoliciesAreEqual(f.defaultNetworkPolicies["karydia-default-network-policy-l2"], reconciledPolicy) {
-		t.Errorf("No reconcilation happened")
+		t.Error("No reconcilation happened")
 	}
 }

--- a/pkg/k8sutil/authorizer.go
+++ b/pkg/k8sutil/authorizer.go
@@ -1,4 +1,6 @@
-// Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+// Copyright (C) 2019 SAP SE or an SAP affiliate company. All rights reserved.
+// This file is licensed under the Apache Software License, v. 2 except as
+// noted otherwise in the LICENSE file.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/k8sutil/clientset.go
+++ b/pkg/k8sutil/clientset.go
@@ -1,4 +1,6 @@
-// Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+// Copyright (C) 2019 SAP SE or an SAP affiliate company. All rights reserved.
+// This file is licensed under the Apache Software License, v. 2 except as
+// noted otherwise in the LICENSE file.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -1,0 +1,194 @@
+// Copyright (C) 2019 SAP SE or an SAP affiliate company. All rights reserved.
+// This file is licensed under the Apache Software License, v. 2 except as
+// noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logger
+
+import (
+	"github.com/sirupsen/logrus"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+type Logger struct {
+	baseLogger *logrus.Logger
+	component  string
+	entry      entry
+}
+type entry struct {
+	*logrus.Entry
+}
+
+func GetCallersPackagename() string {
+	return filepath.Base(filepath.Dir(getCallersFile()))
+}
+func GetCallersFilename() string {
+	var file = getCallersFile()
+	return strings.TrimSuffix(filepath.Base(file), filepath.Ext(file))
+}
+func getCallersFile() string {
+	var _, file, _, ok = runtime.Caller(2)
+	if !ok {
+		file = "---UNKNOWN---"
+	}
+	return file
+}
+
+func NewLogger() *Logger {
+	var baseLogger = logrus.New()
+	var logger = &Logger{baseLogger: baseLogger}
+	logger.baseLogger.Formatter = &logrus.JSONFormatter{}
+	logger.baseLogger.Out = os.Stdout
+	logger.baseLogger.Level = logrus.TraceLevel
+	logger.entry = *logger.log()
+	return logger
+}
+func NewComponentLogger(componentName string) *Logger {
+	var logger = NewLogger()
+	logger.SetComponent(componentName)
+	return logger
+}
+
+func (l *Logger) SetComponent(name string) {
+	l.component = name
+	l.entry = *l.log()
+}
+func (l *Logger) GetComponent() string {
+	return l.component
+}
+
+func (l *Logger) log() *entry {
+	var fields = logrus.Fields{}
+	if len(l.component) > 0 {
+		fields["component"] = l.component
+	}
+	return &entry{l.baseLogger.WithFields(fields)}
+}
+func (l *Logger) logWithAdditionalFields(additionalFields map[string]interface{}) *entry {
+	return &entry{l.log().WithFields(additionalFields)}
+}
+
+func (e *entry) prependStrToFormat(prefix, main string) string {
+	var format = main
+	if len(prefix) > 0 {
+		format = prefix + " " + main
+	}
+	return format
+}
+func (e *entry) prependStrToArgs(prefix string, main ...interface{}) []interface{} {
+	var args = main
+	if len(prefix) > 0 {
+		args = append([]interface{}{prefix}, main...)
+	}
+	return args
+}
+
+type Level int
+
+const (
+	debugLevel Level = 2 + iota
+	infoLevel
+	warnLevel
+	errorLevel
+	fatalLevel
+	panicLevel
+)
+
+var levelFormats = map[Level]string{
+	debugLevel: "[DEBUG_INFO]",
+	infoLevel:  "[INFO]",
+	warnLevel:  "[WARN]",
+	errorLevel: "[ERROR]",
+	fatalLevel: "[FATAL]",
+	panicLevel: "[PANIC]",
+}
+
+func (e *entry) f(level Level, format string, args ...interface{}) {
+	var functions = map[Level]func(string, ...interface{}){
+		debugLevel: e.Debugf,
+		infoLevel:  e.Infof,
+		warnLevel:  e.Warnf,
+		errorLevel: e.Errorf,
+		fatalLevel: e.Fatalf,
+		panicLevel: e.Panicf,
+	}
+	functions[level](e.prependStrToFormat(levelFormats[level], format), args...)
+}
+func (e *entry) ln(level Level, args ...interface{}) {
+	var functions = map[Level]func(...interface{}){
+		debugLevel: e.Debugln,
+		infoLevel:  e.Infoln,
+		warnLevel:  e.Warnln,
+		errorLevel: e.Errorln,
+		fatalLevel: e.Fatalln,
+		panicLevel: e.Panicln,
+	}
+	functions[level](e.prependStrToArgs(levelFormats[level], args...)...)
+}
+
+func (l *Logger) HandleCrash() {
+	if r := recover(); r != nil {
+		var entry = l.logWithAdditionalFields(map[string]interface{}{
+			"handleCrash": "autoLog",
+		})
+		// guard against too large logs
+		const size = 64 << 10
+		stacktrace := make([]byte, size)
+		stacktrace = stacktrace[:runtime.Stack(stacktrace, false)]
+		if _, ok := r.(string); ok {
+			entry.f(panicLevel, "%s\n%s", r, stacktrace)
+		} else {
+			entry.f(panicLevel, "%#v (%v)\n%s", r, r, stacktrace)
+		}
+		panic(r)
+	}
+}
+
+func (l *Logger) Debugf(format string, args ...interface{}) {
+	l.entry.f(debugLevel, format, args...)
+}
+func (l *Logger) Debugln(args ...interface{}) {
+	l.entry.ln(debugLevel, args...)
+}
+
+func (l *Logger) Infof(format string, args ...interface{}) {
+	l.entry.f(infoLevel, format, args...)
+}
+func (l *Logger) Infoln(args ...interface{}) {
+	l.entry.ln(infoLevel, args...)
+}
+
+func (l *Logger) Warnf(format string, args ...interface{}) {
+	l.entry.f(warnLevel, format, args...)
+}
+func (l *Logger) Warnln(args ...interface{}) {
+	l.entry.ln(warnLevel, args...)
+}
+
+func (l *Logger) Errorf(format string, args ...interface{}) {
+	l.entry.f(errorLevel, format, args...)
+}
+func (l *Logger) Errorln(args ...interface{}) {
+	l.entry.ln(errorLevel, args...)
+}
+
+func (l *Logger) Fatalf(format string, args ...interface{}) {
+	l.entry.f(fatalLevel, format, args...)
+}
+func (l *Logger) Fatalln(args ...interface{}) {
+	l.entry.ln(fatalLevel, args...)
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -19,11 +19,10 @@ package server
 import (
 	"context"
 	"crypto/tls"
-	"github.com/karydia/karydia/pkg/logger"
-	"net/http"
-
 	"github.com/karydia/karydia"
+	"github.com/karydia/karydia/pkg/logger"
 	"github.com/karydia/karydia/pkg/webhook"
+	"net/http"
 )
 
 type Server struct {
@@ -48,7 +47,7 @@ func New(config *Config, webhook *webhook.Webhook) (*Server, error) {
 	}
 
 	if config.Logger == nil {
-		server.logger = logger.NewComponentLogger("server")
+		server.logger = logger.NewComponentLogger(logger.GetCallersPackagename())
 	} else {
 		// convenience
 		server.logger = config.Logger
@@ -78,13 +77,13 @@ func New(config *Config, webhook *webhook.Webhook) (*Server, error) {
 }
 
 func (s *Server) ListenAndServe() error {
-	s.logger.Infof("karydia server version: %s", karydia.Version)
-	s.logger.Infof("Listening on %s", s.config.Addr)
+	s.logger.Infoln("karydia server version:", karydia.Version)
+	s.logger.Infoln("Listening on", s.config.Addr)
 	return s.httpServer.ListenAndServeTLS("", "")
 }
 
 func (s *Server) Shutdown(ctx context.Context) error {
-	s.logger.Infof("Shutting down ...")
+	s.logger.Infoln("Shutting down")
 	return s.httpServer.Shutdown(ctx)
 }
 
@@ -106,6 +105,6 @@ func (s *Server) middlewareLogger(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		rw := &responseWriter{w, http.StatusOK}
 		next.ServeHTTP(rw, r)
-		s.logger.Infof("remote_addr: %s; method: %s; status: %s; url: %s", r.RemoteAddr, r.Method, rw.status, r.URL)
+		s.logger.Debugf("remote_addr: %s; method: %s; status: %d; url: %s", r.RemoteAddr, r.Method, rw.status, r.URL.String())
 	})
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1,4 +1,6 @@
-// Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+// Copyright (C) 2019 SAP SE or an SAP affiliate company. All rights reserved.
+// This file is licensed under the Apache Software License, v. 2 except as
+// noted otherwise in the LICENSE file.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,9 +19,8 @@ package server
 import (
 	"context"
 	"crypto/tls"
+	"github.com/karydia/karydia/pkg/logger"
 	"net/http"
-
-	"github.com/sirupsen/logrus"
 
 	"github.com/karydia/karydia"
 	"github.com/karydia/karydia/pkg/webhook"
@@ -28,7 +29,7 @@ import (
 type Server struct {
 	config *Config
 
-	logger *logrus.Logger
+	logger *logger.Logger
 
 	httpServer *http.Server
 }
@@ -36,7 +37,7 @@ type Server struct {
 type Config struct {
 	Addr string
 
-	Logger *logrus.Logger
+	Logger *logger.Logger
 
 	TLSConfig *tls.Config
 }
@@ -47,8 +48,7 @@ func New(config *Config, webhook *webhook.Webhook) (*Server, error) {
 	}
 
 	if config.Logger == nil {
-		server.logger = logrus.New()
-		server.logger.Level = logrus.InfoLevel
+		server.logger = logger.NewComponentLogger("server")
 	} else {
 		// convenience
 		server.logger = config.Logger
@@ -106,10 +106,6 @@ func (s *Server) middlewareLogger(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		rw := &responseWriter{w, http.StatusOK}
 		next.ServeHTTP(rw, r)
-		s.logger.WithFields(logrus.Fields{
-			"remote_addr": r.RemoteAddr,
-			"method":      r.Method,
-			"status":      rw.status,
-		}).Infof("%s", r.URL)
+		s.logger.Infof("remote_addr: %s; method: %s; status: %s; url: %s", r.RemoteAddr, r.Method, rw.status, r.URL)
 	})
 }

--- a/pkg/util/tls/tls.go
+++ b/pkg/util/tls/tls.go
@@ -1,4 +1,6 @@
-// Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+// Copyright (C) 2019 SAP SE or an SAP affiliate company. All rights reserved.
+// This file is licensed under the Apache Software License, v. 2 except as
+// noted otherwise in the LICENSE file.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -1,4 +1,6 @@
-// Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+// Copyright (C) 2019 SAP SE or an SAP affiliate company. All rights reserved.
+// This file is licensed under the Apache Software License, v. 2 except as
+// noted otherwise in the LICENSE file.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,10 +19,10 @@ package webhook
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/karydia/karydia/pkg/logger"
 	"io/ioutil"
 	"net/http"
 
-	"github.com/sirupsen/logrus"
 	"k8s.io/api/admission/v1beta1"
 
 	"github.com/karydia/karydia/pkg/admission"
@@ -29,13 +31,13 @@ import (
 )
 
 type Webhook struct {
-	logger *logrus.Logger
+	logger *logger.Logger
 
 	admissionPlugins []admission.AdmissionPlugin
 }
 
 type Config struct {
-	Logger *logrus.Logger
+	Logger *logger.Logger
 }
 
 func New(config *Config) (*Webhook, error) {
@@ -44,8 +46,7 @@ func New(config *Config) (*Webhook, error) {
 	}
 
 	if config.Logger == nil {
-		webhook.logger = logrus.New()
-		webhook.logger.Level = logrus.InfoLevel
+		webhook.logger = logger.NewComponentLogger("webhook")
 	} else {
 		// convenience
 		webhook.logger = config.Logger
@@ -107,7 +108,7 @@ func (wh *Webhook) Serve(w http.ResponseWriter, r *http.Request, mutationAllowed
 	}
 
 	if len(body) == 0 {
-		wh.logger.Error("received request with empty body")
+		wh.logger.Errorln("received request with empty body")
 		http.Error(w, "empty body", http.StatusBadRequest)
 		return
 	}

--- a/scripts/configure-karydia-webhook
+++ b/scripts/configure-karydia-webhook
@@ -1,5 +1,5 @@
 #!/bin/bash
-#
+
 # Copyright (C) 2019 SAP SE or an SAP affiliate company. All rights reserved.
 # This file is licensed under the Apache Software License, v. 2 except as
 # noted otherwise in the LICENSE file.
@@ -15,6 +15,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 set -euo pipefail
 
 ca_bundle="$(kubectl get configmap -n kube-system extension-apiserver-authentication -o=jsonpath='{.data.client-ca-file}' | base64 | tr -d '\r\n')"

--- a/scripts/create-karydia-certificate
+++ b/scripts/create-karydia-certificate
@@ -1,6 +1,8 @@
 #!/bin/bash
-#
-# Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+
+# Copyright (C) 2019 SAP SE or an SAP affiliate company. All rights reserved.
+# This file is licensed under the Apache Software License, v. 2 except as
+# noted otherwise in the LICENSE file.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +15,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 set -euo pipefail
 
 for req in kubectl openssl; do

--- a/scripts/create-karydia-tls-secret
+++ b/scripts/create-karydia-tls-secret
@@ -1,6 +1,8 @@
 #!/bin/bash
-#
-# Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+
+# Copyright (C) 2019 SAP SE or an SAP affiliate company. All rights reserved.
+# This file is licensed under the Apache Software License, v. 2 except as
+# noted otherwise in the LICENSE file.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +15,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 set -euo pipefail
 
 readonly secret_name="${SECRET_NAME:-karydia-tls}"

--- a/scripts/hotswap-dev
+++ b/scripts/hotswap-dev
@@ -110,7 +110,7 @@ NOHUP_ARGUMENTS=''														# add content only if existent
 [ $(echo "${@:2}" | wc -w) -ge 1 ] && NOHUP_ARGUMENTS+=$(echo "${@:2}") || true							# e.g. 'runserver --tls-cert ...'
 
 ## run main binary in separate process with passed parameters if main binary exists otherwise exit
-[ -e "$MAIN_BIN_PATH" ] && (nohup $NOHUP_UTILITY $NOHUP_ARGUMENTS > "$LOG_MAIN" &) || \
+[ -e "$MAIN_BIN_PATH" ] && (nohup $NOHUP_UTILITY $NOHUP_ARGUMENTS 1>&2 | tee "$LOG_MAIN" &) || \
   { printf "$ERROR_LOG_FORMAT" 'binary not found' "Is '$MAIN_BIN_PATH' an absolute path to an existing binary?" >&2 && exit 1; }
 
 ## log activity to STDOUT and file
@@ -154,7 +154,7 @@ do
     mv -f "$WATCH_BIN_PATH" "$MAIN_BIN_PATH"
 
     ## run main binary in separate process with passed parameters if main binary exists otherwise exit
-    [ -e "$MAIN_BIN_PATH" ] && (nohup $NOHUP_UTILITY $NOHUP_ARGUMENTS > "$LOG_MAIN" &) || \
+    [ -e "$MAIN_BIN_PATH" ] && (nohup $NOHUP_UTILITY $NOHUP_ARGUMENTS 1>&2 | tee "$LOG_MAIN" &) || \
       { printf "$ERROR_LOG_FORMAT" 'binary not found' "Is '$MAIN_BIN_PATH' an absolute path to an existing binary?" >&2 && exit 1; }
 
     msg+=' & restarted'

--- a/tests/e2e/admission_automount_token_test.go
+++ b/tests/e2e/admission_automount_token_test.go
@@ -59,7 +59,7 @@ func TestAutomountServiceAccountToken(t *testing.T) {
 			if tc.nsAnnotation == nil {
 				namespace, err = f.CreateTestNamespace()
 				if err != nil {
-					t.Fatalf("failed to create test namespace: %v", err)
+					t.Fatal("failed to create test namespace:", err)
 				}
 			} else {
 				/* Directly annotate namespace to prevent race-conditions with the
@@ -70,7 +70,7 @@ func TestAutomountServiceAccountToken(t *testing.T) {
 				}
 				namespace, err = f.CreateTestNamespaceWithAnnotation(annotation)
 				if err != nil {
-					t.Fatalf("failed to create test namespace: %v", err)
+					t.Fatal("failed to create test namespace:", err)
 				}
 			}
 
@@ -79,21 +79,21 @@ func TestAutomountServiceAccountToken(t *testing.T) {
 			if tc.serviceAccount != "" && tc.serviceAccount != "default" {
 				sAcc, err := f.CreateServiceAccount(tc.serviceAccount, ns)
 				if err != nil {
-					t.Fatalf("failed to create service account: %v", err)
+					t.Fatal("failed to create service account:", err)
 				}
 				if tc.nsAnnotation != nil && *tc.nsAnnotation == "change-default" {
 					if sAcc.AutomountServiceAccountToken != nil {
-						t.Fatalf("expected service account automount to be undefined")
+						t.Fatal("expected service account automount to be undefined")
 					}
 				} else if tc.nsAnnotation != nil && *tc.nsAnnotation == "change-all" {
 					if sAcc.AutomountServiceAccountToken != nil && *sAcc.AutomountServiceAccountToken != false {
-						t.Fatalf("expected service account automount to be false")
+						t.Fatal("expected service account automount to be false")
 					}
 				}
 			} else {
 				timeout := 3000 * time.Millisecond
 				if err := f.WaitDefaultServiceAccountCreated(ns, timeout); err != nil {
-					t.Fatalf("default service account not created: %v", err)
+					t.Fatal("default service account not created:", err)
 				}
 			}
 
@@ -102,7 +102,7 @@ func TestAutomountServiceAccountToken(t *testing.T) {
 			if err != nil {
 				err = updateServiceAccount(tc, ns)
 				if err != nil {
-					t.Fatalf("could not update service account: %v", err)
+					t.Fatal("could not update service account:", err)
 				}
 			}
 
@@ -128,7 +128,7 @@ func TestAutomountServiceAccountToken(t *testing.T) {
 
 			createdPod, err := f.KubeClientset.CoreV1().Pods(ns).Create(pod)
 			if err != nil {
-				t.Fatalf("failed to create pod: %v", err)
+				t.Fatal("failed to create pod:", err)
 			}
 
 			if createdPod.Spec.AutomountServiceAccountToken != nil && *createdPod.Spec.AutomountServiceAccountToken != tc.mounted {
@@ -141,7 +141,7 @@ func TestAutomountServiceAccountToken(t *testing.T) {
 
 			timeout := 2 * time.Minute
 			if err := f.WaitPodRunning(pod.ObjectMeta.Namespace, pod.ObjectMeta.Name, timeout); err != nil {
-				t.Fatalf("pod never reached state running")
+				t.Fatal("pod never reached state running")
 			}
 		})
 	}
@@ -173,21 +173,21 @@ func TestAutomountServiceAccountTokenInDefaultNamespace(t *testing.T) {
 
 	createdPod, err := f.KubeClientset.CoreV1().Pods(ns).Create(pod)
 	if err != nil {
-		t.Fatalf("failed to create pod: %v", err)
+		t.Fatal("failed to create pod:", err)
 	}
 
 	if createdPod.Spec.AutomountServiceAccountToken != nil {
-		t.Fatalf("expected automountServiceAccountToken to be nil but is %v", createdPod.Spec.AutomountServiceAccountToken)
+		t.Fatal("expected automountServiceAccountToken to be nil but is", createdPod.Spec.AutomountServiceAccountToken)
 	}
 
 	if !(len(createdPod.Spec.Volumes) == 0) {
 		/* Change to t.Fatalf when karydia setup is finished */
-		t.Logf("expected is mounted to be false but is true")
+		t.Log("expected is mounted to be false but is true")
 	}
 
 	timeout := 2 * time.Minute
 	if err := f.WaitPodRunning(pod.ObjectMeta.Namespace, pod.ObjectMeta.Name, timeout); err != nil {
-		t.Fatalf("pod never reached state running")
+		t.Fatal("pod never reached state running")
 	}
 }
 
@@ -201,32 +201,32 @@ func TestAutomountServiceAccountTokenEditServiceAccount(t *testing.T) {
 	}
 	namespace, err = f.CreateTestNamespaceWithAnnotation(annotation)
 	if err != nil {
-		t.Fatalf("failed to create test namespace: %v", err)
+		t.Fatal("failed to create test namespace:", err)
 	}
 
 	ns := namespace.ObjectMeta.Name
 
 	sAcc, err := f.CreateServiceAccount("dedicated", ns)
 	if err != nil {
-		t.Fatalf("failed to create service account: %v", err)
+		t.Fatal("failed to create service account:", err)
 	}
 
 	automount := true
 	sAcc.AutomountServiceAccountToken = &automount
 	sAcc, err = f.KubeClientset.CoreV1().ServiceAccounts(ns).Update(sAcc)
 	if err != nil {
-		t.Fatalf("failed to update service account: %v", err)
+		t.Fatal("failed to update service account:", err)
 	}
 
 	/* Test update resource ServiceAccount */
 	sAcc.AutomountServiceAccountToken = nil
 	sAcc, err = f.KubeClientset.CoreV1().ServiceAccounts(ns).Update(sAcc)
 	if err != nil {
-		t.Fatalf("failed to update service account: %v", err)
+		t.Fatal("failed to update service account:", err)
 	}
 
 	if sAcc.AutomountServiceAccountToken == nil {
-		t.Fatalf("expected updated service account to have automoutnServiceAccountToken set to false but is nil")
+		t.Fatal("expected updated service account to have automoutnServiceAccountToken set to false but is nil")
 	}
 }
 
@@ -239,21 +239,21 @@ func TestAutomountServiceAccountTokenDefaultServiceAccountFromConfig(t *testing.
 	}
 	namespace, err = f.CreateTestNamespaceWithAnnotation(annotation)
 	if err != nil {
-		t.Fatalf("failed to create test namespace: %v", err)
+		t.Fatal("failed to create test namespace:", err)
 	}
 
 	ns := namespace.ObjectMeta.Name
 	timeout := 3000 * time.Millisecond
 	if err := f.WaitDefaultServiceAccountCreated(ns, timeout); err != nil {
-		t.Fatalf("default service account not created: %v", err)
+		t.Fatal("default service account not created:", err)
 	}
 	sAcc, err := f.KubeClientset.CoreV1().ServiceAccounts(ns).Get("default", metav1.GetOptions{})
 	if err != nil {
-		t.Fatalf("failed to get service account: %v", err)
+		t.Fatal("failed to get service account:", err)
 	}
 
 	if *sAcc.AutomountServiceAccountToken != false {
-		t.Fatalf("expected service account to have automountServiceAccountToken set to false but is %v",
+		t.Fatal("expected service account to have automountServiceAccountToken set to false but is",
 			sAcc.AutomountServiceAccountToken)
 	}
 
@@ -274,20 +274,20 @@ func TestAutomountServiceAccountTokenDefaultServiceAccountFromConfig(t *testing.
 
 	createdPod, err := f.KubeClientset.CoreV1().Pods(ns).Create(pod)
 	if err != nil {
-		t.Fatalf("failed to create pod: %v", err)
+		t.Fatal("failed to create pod:", err)
 	}
 
 	if createdPod.Spec.AutomountServiceAccountToken != nil {
-		t.Fatalf("expected automountServiceAccountToken to be nil but is %v", createdPod.Spec.AutomountServiceAccountToken)
+		t.Fatal("expected automountServiceAccountToken to be nil but is", createdPod.Spec.AutomountServiceAccountToken)
 	}
 
 	if !(len(createdPod.Spec.Volumes) == 0) {
-		t.Fatalf("expected is mounted to be false but is true")
+		t.Fatal("expected is mounted to be false but is true")
 	}
 
 	timeout = 2 * time.Minute
 	if err := f.WaitPodRunning(pod.ObjectMeta.Namespace, pod.ObjectMeta.Name, timeout); err != nil {
-		t.Fatalf("pod never reached state running")
+		t.Fatal("pod never reached state running")
 	}
 }
 
@@ -300,22 +300,22 @@ func TestAutomountServiceAccountTokenDedicatedServiceAccountFromConfig(t *testin
 	}
 	namespace, err = f.CreateTestNamespaceWithAnnotation(annotation)
 	if err != nil {
-		t.Fatalf("failed to create test namespace: %v", err)
+		t.Fatal("failed to create test namespace:", err)
 	}
 
 	ns := namespace.ObjectMeta.Name
 	timeout := 3000 * time.Millisecond
 	sAcc, err := f.CreateServiceAccount("dedicated", ns)
 	if err != nil {
-		t.Fatalf("failed to create service account: %v", err)
+		t.Fatal("failed to create service account:", err)
 	}
 	sAcc, err = f.KubeClientset.CoreV1().ServiceAccounts(ns).Get("dedicated", metav1.GetOptions{})
 	if err != nil {
-		t.Fatalf("failed to get service account: %v", err)
+		t.Fatal("failed to get service account:", err)
 	}
 
 	if sAcc.AutomountServiceAccountToken != nil {
-		t.Fatalf("expected service account to have automountServiceAccountToken set to nil but is %v",
+		t.Fatal("expected service account to have automountServiceAccountToken set to nil but is",
 			sAcc.AutomountServiceAccountToken)
 	}
 
@@ -337,20 +337,20 @@ func TestAutomountServiceAccountTokenDedicatedServiceAccountFromConfig(t *testin
 
 	createdPod, err := f.KubeClientset.CoreV1().Pods(ns).Create(pod)
 	if err != nil {
-		t.Fatalf("failed to create pod: %v", err)
+		t.Fatal("failed to create pod:", err)
 	}
 
 	if createdPod.Spec.AutomountServiceAccountToken != nil {
-		t.Fatalf("expected automountServiceAccountToken to be nil but is %v", createdPod.Spec.AutomountServiceAccountToken)
+		t.Fatal("expected automountServiceAccountToken to be nil but is", createdPod.Spec.AutomountServiceAccountToken)
 	}
 
 	if !(len(createdPod.Spec.Volumes) == 1) {
-		t.Fatalf("expected is mounted to be true but is false")
+		t.Fatal("expected is mounted to be true but is false")
 	}
 
 	timeout = 2 * time.Minute
 	if err := f.WaitPodRunning(pod.ObjectMeta.Namespace, pod.ObjectMeta.Name, timeout); err != nil {
-		t.Fatalf("pod never reached state running")
+		t.Fatal("pod never reached state running")
 	}
 }
 

--- a/tests/e2e/admission_seccomp_test.go
+++ b/tests/e2e/admission_seccomp_test.go
@@ -31,7 +31,7 @@ func TestSeccompWithNamespaceAnnotationUndefinedProfile(t *testing.T) {
 	}
 	namespace, err := f.CreateTestNamespaceWithAnnotation(annotation)
 	if err != nil {
-		t.Fatalf("failed to create test namespace: %v", err)
+		t.Fatal("failed to create test namespace:", err)
 	}
 
 	ns := namespace.ObjectMeta.Name
@@ -53,7 +53,7 @@ func TestSeccompWithNamespaceAnnotationUndefinedProfile(t *testing.T) {
 
 	createdPod, err := f.KubeClientset.CoreV1().Pods(ns).Create(pod)
 	if err != nil {
-		t.Fatalf("failed to create pod: %v", err)
+		t.Fatal("failed to create pod:", err)
 	}
 
 	if profile := createdPod.ObjectMeta.Annotations["seccomp.security.alpha.kubernetes.io/pod"]; profile != "runtime/default" {
@@ -62,7 +62,7 @@ func TestSeccompWithNamespaceAnnotationUndefinedProfile(t *testing.T) {
 
 	timeout := 2 * time.Minute
 	if err := f.WaitPodRunning(pod.ObjectMeta.Namespace, pod.ObjectMeta.Name, timeout); err != nil {
-		t.Fatalf("pod never reached state running")
+		t.Fatal("pod never reached state running")
 	}
 }
 
@@ -73,7 +73,7 @@ func TestSeccompWithNamespaceAnnotationDefinedProfile(t *testing.T) {
 	}
 	namespace, err := f.CreateTestNamespaceWithAnnotation(annotation)
 	if err != nil {
-		t.Fatalf("failed to create test namespace: %v", err)
+		t.Fatal("failed to create test namespace:", err)
 	}
 
 	ns := namespace.ObjectMeta.Name
@@ -98,7 +98,7 @@ func TestSeccompWithNamespaceAnnotationDefinedProfile(t *testing.T) {
 
 	createdPod, err := f.KubeClientset.CoreV1().Pods(ns).Create(pod)
 	if err != nil {
-		t.Fatalf("failed to create pod: %v", err)
+		t.Fatal("failed to create pod:", err)
 	}
 
 	if profile := createdPod.ObjectMeta.Annotations["seccomp.security.alpha.kubernetes.io/pod"]; profile != "runtime/default" {
@@ -107,7 +107,7 @@ func TestSeccompWithNamespaceAnnotationDefinedProfile(t *testing.T) {
 
 	timeout := 2 * time.Minute
 	if err := f.WaitPodRunning(pod.ObjectMeta.Namespace, pod.ObjectMeta.Name, timeout); err != nil {
-		t.Fatalf("pod never reached state running")
+		t.Fatal("pod never reached state running")
 	}
 }
 
@@ -117,7 +117,7 @@ func TestSeccompWithoutNamespaceAnnotationUndefinedProfileFromConfig(t *testing.
 	}
 	namespace, err := f.CreateTestNamespaceWithAnnotation(annotation)
 	if err != nil {
-		t.Fatalf("failed to create test namespace: %v", err)
+		t.Fatal("failed to create test namespace:", err)
 	}
 
 	ns := namespace.ObjectMeta.Name
@@ -139,7 +139,7 @@ func TestSeccompWithoutNamespaceAnnotationUndefinedProfileFromConfig(t *testing.
 
 	createdPod, err := f.KubeClientset.CoreV1().Pods(ns).Create(pod)
 	if err != nil {
-		t.Fatalf("failed to create pod: %v", err)
+		t.Fatal("failed to create pod:", err)
 	}
 
 	if profile := createdPod.ObjectMeta.Annotations["seccomp.security.alpha.kubernetes.io/pod"]; profile != "runtime/default" {
@@ -148,7 +148,7 @@ func TestSeccompWithoutNamespaceAnnotationUndefinedProfileFromConfig(t *testing.
 
 	timeout := 2 * time.Minute
 	if err := f.WaitPodRunning(pod.ObjectMeta.Namespace, pod.ObjectMeta.Name, timeout); err != nil {
-		t.Fatalf("pod never reached state running")
+		t.Fatal("pod never reached state running")
 	}
 }
 
@@ -159,7 +159,7 @@ func TestSeccompWithNamespaceAnnotationUndefinedProfileFromConfig(t *testing.T) 
 	}
 	namespace, err := f.CreateTestNamespaceWithAnnotation(annotation)
 	if err != nil {
-		t.Fatalf("failed to create test namespace: %v", err)
+		t.Fatal("failed to create test namespace:", err)
 	}
 
 	ns := namespace.ObjectMeta.Name
@@ -181,7 +181,7 @@ func TestSeccompWithNamespaceAnnotationUndefinedProfileFromConfig(t *testing.T) 
 
 	createdPod, err := f.KubeClientset.CoreV1().Pods(ns).Create(pod)
 	if err != nil {
-		t.Fatalf("failed to create pod: %v", err)
+		t.Fatal("failed to create pod:", err)
 	}
 
 	if profile := createdPod.ObjectMeta.Annotations["seccomp.security.alpha.kubernetes.io/pod"]; profile != "unconfined" {
@@ -190,7 +190,7 @@ func TestSeccompWithNamespaceAnnotationUndefinedProfileFromConfig(t *testing.T) 
 
 	timeout := 2 * time.Minute
 	if err := f.WaitPodRunning(pod.ObjectMeta.Namespace, pod.ObjectMeta.Name, timeout); err != nil {
-		t.Fatalf("pod never reached state running")
+		t.Fatal("pod never reached state running")
 	}
 }
 
@@ -200,7 +200,7 @@ func TestSeccompWithoutNamespaceAnnotationDefinedProfile(t *testing.T) {
 	}
 	namespace, err := f.CreateTestNamespaceWithAnnotation(annotation)
 	if err != nil {
-		t.Fatalf("failed to create test namespace: %v", err)
+		t.Fatal("failed to create test namespace:", err)
 	}
 
 	ns := namespace.ObjectMeta.Name
@@ -225,7 +225,7 @@ func TestSeccompWithoutNamespaceAnnotationDefinedProfile(t *testing.T) {
 
 	createdPod, err := f.KubeClientset.CoreV1().Pods(ns).Create(pod)
 	if err != nil {
-		t.Fatalf("failed to create pod: %v", err)
+		t.Fatal("failed to create pod:", err)
 	}
 
 	if profile := createdPod.ObjectMeta.Annotations["seccomp.security.alpha.kubernetes.io/pod"]; profile != "runtime/default" {
@@ -234,6 +234,6 @@ func TestSeccompWithoutNamespaceAnnotationDefinedProfile(t *testing.T) {
 
 	timeout := 2 * time.Minute
 	if err := f.WaitPodRunning(pod.ObjectMeta.Namespace, pod.ObjectMeta.Name, timeout); err != nil {
-		t.Fatalf("pod never reached state running")
+		t.Fatal("pod never reached state running")
 	}
 }

--- a/tests/e2e/admission_security_context_test.go
+++ b/tests/e2e/admission_security_context_test.go
@@ -30,7 +30,7 @@ func TestSecurityContextWithNamespaceAnnotationUndefinedContext(t *testing.T) {
 	}
 	namespace, err := f.CreateTestNamespaceWithAnnotation(annotation)
 	if err != nil {
-		t.Fatalf("failed to create test namespace: %v", err)
+		t.Fatal("failed to create test namespace:", err)
 	}
 
 	ns := namespace.ObjectMeta.Name
@@ -52,12 +52,12 @@ func TestSecurityContextWithNamespaceAnnotationUndefinedContext(t *testing.T) {
 
 	createdPod, err := f.KubeClientset.CoreV1().Pods(ns).Create(pod)
 	if err != nil {
-		t.Fatalf("failed to create pod: %v", err)
+		t.Fatal("failed to create pod:", err)
 	}
 
 	secCtx := createdPod.Spec.SecurityContext
 	if secCtx == nil {
-		t.Fatalf("expected security context to be defined by admssion but is nil")
+		t.Fatal("expected security context to be defined by admssion but is nil")
 	} else if *secCtx.RunAsUser != 65534 {
 		t.Fatalf("expected security context user id to be %v but is %v", 65534, *secCtx.RunAsUser)
 	} else if *secCtx.RunAsGroup != 65534 {
@@ -66,7 +66,7 @@ func TestSecurityContextWithNamespaceAnnotationUndefinedContext(t *testing.T) {
 
 	timeout := 2 * time.Minute
 	if err := f.WaitPodRunning(pod.ObjectMeta.Namespace, pod.ObjectMeta.Name, timeout); err != nil {
-		t.Fatalf("pod never reached state running")
+		t.Fatal("pod never reached state running")
 	}
 }
 
@@ -76,7 +76,7 @@ func TestSecurityContextWithNamespaceAnnotationDefinedContext(t *testing.T) {
 	}
 	namespace, err := f.CreateTestNamespaceWithAnnotation(annotation)
 	if err != nil {
-		t.Fatalf("failed to create test namespace: %v", err)
+		t.Fatal("failed to create test namespace:", err)
 	}
 
 	ns := namespace.ObjectMeta.Name
@@ -103,12 +103,12 @@ func TestSecurityContextWithNamespaceAnnotationDefinedContext(t *testing.T) {
 
 	createdPod, err := f.KubeClientset.CoreV1().Pods(ns).Create(pod)
 	if err != nil {
-		t.Fatalf("failed to create pod: %v", err)
+		t.Fatal("failed to create pod:", err)
 	}
 
 	secCtx := createdPod.Spec.SecurityContext
 	if secCtx == nil {
-		t.Fatalf("expected security context to be defined by pod definition but is nil")
+		t.Fatal("expected security context to be defined by pod definition but is nil")
 	} else if *secCtx.RunAsUser != 1000 {
 		t.Fatalf("expected security context user id to be %v but is %v", 1000, *secCtx.RunAsUser)
 	} else if secCtx.RunAsGroup != nil {
@@ -117,7 +117,7 @@ func TestSecurityContextWithNamespaceAnnotationDefinedContext(t *testing.T) {
 
 	timeout := 2 * time.Minute
 	if err := f.WaitPodRunning(pod.ObjectMeta.Namespace, pod.ObjectMeta.Name, timeout); err != nil {
-		t.Fatalf("pod never reached state running")
+		t.Fatal("pod never reached state running")
 	}
 }
 
@@ -125,7 +125,7 @@ func TestSecurityContextWithoutNamespaceAnnotationUndefinedContextFromConfig(t *
 	annotation := map[string]string{}
 	namespace, err := f.CreateTestNamespaceWithAnnotation(annotation)
 	if err != nil {
-		t.Fatalf("failed to create test namespace: %v", err)
+		t.Fatal("failed to create test namespace:", err)
 	}
 
 	ns := namespace.ObjectMeta.Name
@@ -147,12 +147,12 @@ func TestSecurityContextWithoutNamespaceAnnotationUndefinedContextFromConfig(t *
 
 	createdPod, err := f.KubeClientset.CoreV1().Pods(ns).Create(pod)
 	if err != nil {
-		t.Fatalf("failed to create pod: %v", err)
+		t.Fatal("failed to create pod:", err)
 	}
 
 	secCtx := createdPod.Spec.SecurityContext
 	if secCtx == nil {
-		t.Fatalf("expected security context to be defined by admssion but is nil")
+		t.Fatal("expected security context to be defined by admssion but is nil")
 	} else if *secCtx.RunAsUser != 65534 {
 		t.Fatalf("expected security context user id to be %v but is %v", 65534, *secCtx.RunAsUser)
 	} else if *secCtx.RunAsGroup != 65534 {
@@ -161,6 +161,6 @@ func TestSecurityContextWithoutNamespaceAnnotationUndefinedContextFromConfig(t *
 
 	timeout := 2 * time.Minute
 	if err := f.WaitPodRunning(pod.ObjectMeta.Namespace, pod.ObjectMeta.Name, timeout); err != nil {
-		t.Fatalf("pod never reached state running")
+		t.Fatal("pod never reached state running")
 	}
 }

--- a/tests/e2e/framework/framework.go
+++ b/tests/e2e/framework/framework.go
@@ -51,17 +51,17 @@ func Setup(server, kubeconfig, namespace string) (*Framework, error) {
 	}
 	cfg, err := clientcmd.BuildConfigFromFlags(server, kubeconfig)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to build kubeconfig: %v\n", err)
+		fmt.Fprintln(os.Stderr, "Failed to build kubeconfig:", err)
 		os.Exit(1)
 	}
 	ApiExtClientset, err := apiextension.NewForConfig(cfg)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to build api extension clientset: %v\n", err)
+		fmt.Fprintln(os.Stderr, "Failed to build api extension clientset:", err)
 		os.Exit(1)
 	}
 	KarydiaClientset, err := clientset.NewForConfig(cfg)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to build karydia clientset: %v\n", err)
+		fmt.Fprintln(os.Stderr, "Failed to build karydia clientset:", err)
 		os.Exit(1)
 	}
 
@@ -102,7 +102,7 @@ func (f *Framework) CreateNamespace() error {
 		ObjectMeta: objectMeta,
 	})
 	if err != nil {
-		return fmt.Errorf("failed to create namespace %q: %v", f.Namespace, err)
+		return fmt.Errorf("failed to create namespace '%s': %v", f.Namespace, err)
 	}
 	f.Namespace = ns.ObjectMeta.Name
 	return nil
@@ -118,7 +118,7 @@ func (f *Framework) CreateTestNamespace() (*corev1.Namespace, error) {
 		},
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to create namespace %q: %v", f.Namespace, err)
+		return nil, fmt.Errorf("failed to create namespace '%s': %v", f.Namespace, err)
 	}
 	return ns, nil
 }
@@ -134,7 +134,7 @@ func (f *Framework) CreateTestNamespaceWithAnnotation(annotations map[string]str
 		},
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to create namespace %q: %v", f.Namespace, err)
+		return nil, fmt.Errorf("failed to create namespace '%s': %v", f.Namespace, err)
 	}
 	return ns, nil
 }
@@ -155,7 +155,7 @@ func (f *Framework) DeleteAll() error {
 		if err := f.KubeClientset.CoreV1().Namespaces().Delete(name, &metav1.DeleteOptions{
 			GracePeriodSeconds: &zero,
 		}); err != nil {
-			return fmt.Errorf("failed to delete namespace %q: %v", name, err)
+			return fmt.Errorf("failed to delete namespace '%s': %v", name, err)
 		}
 	}
 	/* Delete single pod in default namespace */

--- a/tests/e2e/karydia_default_network_policy_test.go
+++ b/tests/e2e/karydia_default_network_policy_test.go
@@ -46,10 +46,10 @@ func execCommandAssertExitCode(t *testing.T, command string, expectedExitCode in
 			exitCode = ws.ExitStatus()
 
 			if exitCode != expectedExitCode {
-				t.Fatalf("Exit status with unexpected code: %d %s", exitCode, command)
+				t.Fatal("Exit status with unexpected code:", exitCode, command)
 			}
 		} else {
-			t.Fatalf("Could not get exit code.")
+			t.Fatal("Could not get exit code.")
 		}
 	} else {
 		// success, exitCode should be 0 if go is ok
@@ -57,7 +57,7 @@ func execCommandAssertExitCode(t *testing.T, command string, expectedExitCode in
 		exitCode = ws.ExitStatus()
 
 		if exitCode != expectedExitCode {
-			t.Fatalf("Exit status with unexpected code: %d %s", exitCode, command)
+			t.Fatal("Exit status with unexpected code:", exitCode, command)
 		}
 	}
 }
@@ -69,7 +69,7 @@ func TestNetworkPolicyLevel1(t *testing.T) {
 
 	namespace, err = f.CreateTestNamespace()
 	if err != nil {
-		t.Fatalf("failed to create test namespace: %v", err)
+		t.Fatal("failed to create test namespace:", err)
 	}
 
 	ns := namespace.ObjectMeta.Name
@@ -92,13 +92,13 @@ func TestNetworkPolicyLevel1(t *testing.T) {
 
 	createdPod, err := f.KubeClientset.CoreV1().Pods(ns).Create(pod)
 	if err != nil {
-		t.Fatalf("Failed to create: " + err.Error())
+		t.Fatal("Failed to create:", err.Error())
 	}
 	podName := createdPod.ObjectMeta.Name
 
 	timeout := 2 * time.Minute
 	if err := f.WaitPodRunning(ns, podName, timeout); err != nil {
-		t.Fatalf("pod never reached state running")
+		t.Fatal("pod never reached state running")
 	}
 
 	// host network (AWS only)
@@ -149,7 +149,7 @@ func TestNetworkPolicyLevel1(t *testing.T) {
 
 	err = f.KubeClientset.CoreV1().Pods(ns).Delete(createdPod.ObjectMeta.Name, &metav1.DeleteOptions{})
 	if err != nil {
-		t.Fatalf("pod could not be deleted")
+		t.Fatal("pod could not be deleted")
 	}
 
 }

--- a/tests/e2e/karydia_network_policy_reconciler_test.go
+++ b/tests/e2e/karydia_network_policy_reconciler_test.go
@@ -37,40 +37,40 @@ func TestCreateKarydiaNetworkPolicyForNewNamespace(t *testing.T) {
 	defaultNetworkPolicy.Name = defaultNetworkPolicyName
 	karydiaNetworkpolicy, err := f.KarydiaClientset.KarydiaV1alpha1().KarydiaNetworkPolicies().Get(defaultNetworkPolicyName, meta_v1.GetOptions{})
 	if err != nil {
-		t.Fatalf("failed to get karydia default network policy: %v", err)
+		t.Fatal("failed to get karydia default network policy:", err)
 	}
 	defaultNetworkPolicy.Spec = *karydiaNetworkpolicy.Spec.DeepCopy()
 	namespace, err := f.CreateTestNamespace()
 	if err != nil {
-		t.Fatalf("failed to create test namespace: %v", err)
+		t.Fatal("failed to create test namespace:", err)
 	}
 
 	timeout := 3000 * time.Millisecond
 	if err := f.WaitNetworkPolicyCreated(namespace.GetName(), defaultNetworkPolicyName, timeout); err != nil {
-		t.Fatalf("failed to create default network policy for new namespace: %v", err)
+		t.Fatal("failed to create default network policy for new namespace:", err)
 	}
 
 	namespaceNetworkPolicy, err := f.KubeClientset.NetworkingV1().NetworkPolicies(namespace.GetName()).Get(defaultNetworkPolicyName, meta_v1.GetOptions{})
 	if err != nil {
-		t.Fatalf("failed to create default network policy for new namespace: %v", err)
+		t.Fatal("failed to create default network policy for new namespace:", err)
 	}
 
 	if !networkPoliciesAreEqual(namespaceNetworkPolicy, defaultNetworkPolicy) {
-		t.Fatalf("Network policy for created namespace is not equal to the default network policy: %v", err)
+		t.Fatal("Network policy for created namespace is not equal to the default network policy:", err)
 	}
 
 	err = f.KubeClientset.NetworkingV1().NetworkPolicies(namespace.GetName()).Delete(defaultNetworkPolicyName, &meta_v1.DeleteOptions{})
 	if err != nil {
-		t.Fatalf("failed to delete default network policy for new namespace: %v", err)
+		t.Fatal("failed to delete default network policy for new namespace:", err)
 	}
 
 	if err := f.WaitNetworkPolicyCreated(namespace.GetName(), defaultNetworkPolicyName, timeout); err != nil {
-		t.Fatalf("failed to create default network policy for new namespace: %v", err)
+		t.Fatal("failed to create default network policy for new namespace:", err)
 	}
 
 	namespaceNetworkPolicy, err = f.KubeClientset.NetworkingV1().NetworkPolicies(namespace.GetName()).Get(defaultNetworkPolicyName, meta_v1.GetOptions{})
 	if err != nil {
-		t.Fatalf("Reconciler failed to recreate default network policy for new namespace: %v", err)
+		t.Fatal("Reconciler failed to recreate default network policy for new namespace:", err)
 	}
 	//Update NP
 	namespaceNetworkPolicy.Spec = networkingv1.NetworkPolicySpec{
@@ -78,7 +78,7 @@ func TestCreateKarydiaNetworkPolicyForNewNamespace(t *testing.T) {
 
 	updatedNetworkPolicy, err := f.KubeClientset.NetworkingV1().NetworkPolicies(namespace.GetName()).Update(namespaceNetworkPolicy)
 	if err != nil {
-		t.Fatalf("failed to update default network policy for new namespace: %v", err)
+		t.Fatal("failed to update default network policy for new namespace:", err)
 	}
 
 	duration := 3 * time.Second
@@ -86,10 +86,10 @@ func TestCreateKarydiaNetworkPolicyForNewNamespace(t *testing.T) {
 
 	updatedNetworkPolicy, err = f.KubeClientset.NetworkingV1().NetworkPolicies(namespace.GetName()).Get(defaultNetworkPolicyName, meta_v1.GetOptions{})
 	if err != nil {
-		t.Fatalf("failed to get default network policy for new namespace: %v", err)
+		t.Fatal("failed to get default network policy for new namespace:", err)
 	}
 	if !networkPoliciesAreEqual(updatedNetworkPolicy, defaultNetworkPolicy) {
-		t.Fatalf("Reconcilation failed after network policy has changed ")
+		t.Fatal("Reconcilation failed after network policy has changed")
 	}
 }
 
@@ -114,42 +114,42 @@ func TestCreateKarydiaNetworkPolicyForAnnotatedNamespace(t *testing.T) {
 
 	_, err := f.KarydiaClientset.KarydiaV1alpha1().KarydiaNetworkPolicies().Create(defaultKarydiaNetworkPolicyL2)
 	if err != nil {
-		t.Fatalf("failed to create: %v", defaultKarydiaNetworkPolicyL2)
+		t.Fatal("failed to create:", defaultKarydiaNetworkPolicyL2)
 	}
 
 	annotations := make(map[string]string)
 	annotations["karydia.gardener.cloud/networkPolicy"] = defaultNetworkPolicyL2Name
 	namespace, err := f.CreateTestNamespaceWithAnnotation(annotations)
 	if err != nil {
-		t.Fatalf("failed to create test namespace: %v", err)
+		t.Fatal("failed to create test namespace:", err)
 	}
 
 	timeout := 3000 * time.Millisecond
 	if err := f.WaitNetworkPolicyCreated(namespace.GetName(), defaultNetworkPolicyL2Name, timeout); err != nil {
-		t.Fatalf("failed to create default network policy for new namespace: %v", err)
+		t.Fatal("failed to create default network policy for new namespace:", err)
 	}
 
 	_, err = f.KubeClientset.NetworkingV1().NetworkPolicies(namespace.GetName()).Get(defaultNetworkPolicyName, meta_v1.GetOptions{})
 	if err == nil {
-		t.Fatalf("Default level 1 network policy should not be found")
+		t.Fatal("Default level 1 network policy should not be found")
 	}
 
 	namespaceNetworkPolicy, err := f.KubeClientset.NetworkingV1().NetworkPolicies(namespace.GetName()).Get(defaultNetworkPolicyL2Name, meta_v1.GetOptions{})
 	if err != nil {
-		t.Fatalf("failed to create default network policy for new namespace: %v", err)
+		t.Fatal("failed to create default network policy for new namespace:", err)
 	}
 
 	if !networkPoliciesAreEqual(namespaceNetworkPolicy, defaultNetworkPolicy) {
-		t.Fatalf("Network policy for created namespace is not equal to the default network policy: %v", err)
+		t.Fatal("Network policy for created namespace is not equal to the default network policy:", err)
 	}
 
 	if err := f.KarydiaClientset.KarydiaV1alpha1().KarydiaNetworkPolicies().Delete(defaultNetworkPolicyL2Name, &meta_v1.DeleteOptions{}); err != nil {
-		t.Fatalf("Failed to delete karydia default network policy l2: %v", err)
+		t.Fatal("Failed to delete karydia default network policy l2:", err)
 	}
 }
 func TestGetKarydiaNetworkPolicyForExcludedNamespace(t *testing.T) {
 	if _, err := f.KubeClientset.NetworkingV1().NetworkPolicies("kube-system").Get(defaultNetworkPolicyName, meta_v1.GetOptions{}); err == nil {
-		t.Fatalf("Default network policy should not be found for excluded namespace ")
+		t.Fatal("Default network policy should not be found for excluded namespace")
 	}
 
 }

--- a/tests/e2e/karydia_network_policy_reconciler_test.go
+++ b/tests/e2e/karydia_network_policy_reconciler_test.go
@@ -1,4 +1,6 @@
-// Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+// Copyright (C) 2019 SAP SE or an SAP affiliate company. All rights reserved.
+// This file is licensed under the Apache Software License, v. 2 except as
+// noted otherwise in the LICENSE file.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/e2e/main_test.go
+++ b/tests/e2e/main_test.go
@@ -43,14 +43,14 @@ func main(m *testing.M) int {
 
 	f, err = framework.Setup(*server, *kubeconfig, *namespace)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to setup framework: %v\n", err)
+		fmt.Fprintln(os.Stderr, "Failed to setup framework:", err)
 		return 1
 	}
 
 	defer func() {
 		if err := f.DeleteAll(); err != nil {
-			fmt.Fprintf(os.Stderr, "Failed to delete karydia and all test resources: %v\n", err)
-			fmt.Fprintf(os.Stderr, "You have to cleanup yourself, sorry\n")
+			fmt.Fprintln(os.Stderr, "Failed to delete karydia and all test resources:", err)
+			fmt.Fprintln(os.Stderr, "You have to cleanup yourself, sorry")
 		}
 	}()
 

--- a/tests/e2e/main_test.go
+++ b/tests/e2e/main_test.go
@@ -1,4 +1,6 @@
-// Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+// Copyright (C) 2019 SAP SE or an SAP affiliate company. All rights reserved.
+// This file is licensed under the Apache Software License, v. 2 except as
+// noted otherwise in the LICENSE file.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/version.go
+++ b/version.go
@@ -1,4 +1,6 @@
-// Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+// Copyright (C) 2019 SAP SE or an SAP affiliate company. All rights reserved.
+// This file is licensed under the Apache Software License, v. 2 except as
+// noted otherwise in the LICENSE file.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
<!-- Thanks for sending a PR -->

### Description
<!-- Feature description or reference to fixed issue -->
Implementation of a unified logger wrapper and replacement of the old different printouts and loggers with this new unified one. Additionally, the hotswap script gets a minor bug fix in terms of wrongly printed log outputs from STDOUT and STDERR.
Furthermore, copyright headers get an update to current wording.

### Checklist
Before submitting this PR, please make sure:
- [x] your code builds clean with `make`
- [x] your code lets succeed unit tests with `make test`
- [x] your code lets succeed integration tests
<!-- Please delete options that are not relevant -->
