### PR TITLE
Remove CRDs and webhooks on delete

### DIFF
--- a/install/charts/templates/delete-clean-up.yaml
+++ b/install/charts/templates/delete-clean-up.yaml
@@ -1,0 +1,37 @@
+# Copyright (C) 2019 SAP SE or an SAP affiliate company. All rights reserved.
+# This file is licensed under the Apache Software License, v. 2 except as
+# noted otherwise in the LICENSE file.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Values.metadata.name }}-delete
+  labels:
+    app: {{ .Values.metadata.labelApp }}
+  namespace: {{ .Values.metadata.namespace }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
+spec:
+  template:
+    metadata:
+      name: {{ .Values.metadata.name }}-pre-delete
+    spec:
+      serviceAccountName: {{ .Values.rbac.serviceAccount }}
+      restartPolicy: OnFailure
+      containers:
+        - name: {{ .Values.metadata.name }}-pre-delete-container
+          image: "lachlanevenson/k8s-kubectl"
+          command: ['sh', '-c', 'kubectl delete mutatingwebhookconfigurations karydia-webhook && kubectl delete validatingwebhookconfigurations karydia-webhook && kubectl delete customresourcedefinitions karydianetworkpolicies.karydia.gardener.cloud && kubectl delete customresourcedefinitions karydiaconfigs.karydia.gardener.cloud']

--- a/install/charts/templates/delete-clean-up.yaml
+++ b/install/charts/templates/delete-clean-up.yaml
@@ -14,22 +14,75 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.rbac.serviceAccount }}-cleanup
+  namespace: {{ .Values.metadata.namespace }}
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
+    "helm.sh/hook-weight": "1"
+
+---
+
+kind: ClusterRole
+apiVersion: {{ .Values.rbac.apiGroup }}{{ .Values.rbac.apiVersion }}
+metadata:
+  name: {{ .Values.metadata.name }}-delete
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
+    "helm.sh/hook-weight": "2"
+rules:
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["delete"]
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources: ["validatingwebhookconfigurations"]
+  verbs: ["delete"]
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources: ["mutatingwebhookconfigurations"]
+  verbs: ["delete"]
+
+---
+
+kind: ClusterRoleBinding
+apiVersion: {{ .Values.rbac.apiGroup }}{{ .Values.rbac.apiVersion }}
+metadata:
+  name: {{ .Values.metadata.name }}-delete
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
+    "helm.sh/hook-weight": "3"
+subjects:
+- kind: ServiceAccount
+  namespace: {{ .Values.metadata.namespace }}
+  name: {{ .Values.rbac.serviceAccount }}-cleanup
+roleRef:
+  kind: ClusterRole
+  name: {{ .Values.metadata.name }}-delete
+  apiGroup: {{ .Values.rbac.apiGroup }}
+
+---
+
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ .Values.metadata.name }}-delete
+  name: {{ .Values.metadata.name }}-cleanup
   labels:
     app: {{ .Values.metadata.labelApp }}
   namespace: {{ .Values.metadata.namespace }}
   annotations:
-    "helm.sh/hook": pre-delete
+    "helm.sh/hook": post-delete
     "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
+    "helm.sh/hook-weight": "4"
 spec:
   template:
     metadata:
       name: {{ .Values.metadata.name }}-pre-delete
     spec:
-      serviceAccountName: {{ .Values.rbac.serviceAccount }}
+      serviceAccountName: {{ .Values.rbac.serviceAccount }}-cleanup
       restartPolicy: Never
       containers:
         - name: {{ .Values.metadata.name }}-pre-delete-container

--- a/install/charts/templates/delete-clean-up.yaml
+++ b/install/charts/templates/delete-clean-up.yaml
@@ -30,7 +30,7 @@ spec:
       name: {{ .Values.metadata.name }}-pre-delete
     spec:
       serviceAccountName: {{ .Values.rbac.serviceAccount }}
-      restartPolicy: OnFailure
+      restartPolicy: Never
       containers:
         - name: {{ .Values.metadata.name }}-pre-delete-container
           image: "lachlanevenson/k8s-kubectl"

--- a/install/charts/templates/delete-clean-up.yaml
+++ b/install/charts/templates/delete-clean-up.yaml
@@ -83,7 +83,7 @@ spec:
       serviceAccountName: {{ .Values.rbac.serviceAccount }}-cleanup
       restartPolicy: Never
       containers:
-        - name: {{ .Values.metadata.name }}-pre-delete-container
+        - name: {{ .Values.metadata.name }}-cleanup-container
           image: "lachlanevenson/k8s-kubectl"
           command:
           - kubectl

--- a/install/charts/templates/delete-clean-up.yaml
+++ b/install/charts/templates/delete-clean-up.yaml
@@ -20,7 +20,7 @@ metadata:
   name: {{ .Values.rbac.serviceAccount }}-cleanup
   namespace: {{ .Values.metadata.namespace }}
   annotations:
-    "helm.sh/hook": post-delete
+    "helm.sh/hook": pre-delete
     "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
     "helm.sh/hook-weight": "1"
 
@@ -31,7 +31,7 @@ apiVersion: {{ .Values.rbac.apiGroup }}{{ .Values.rbac.apiVersion }}
 metadata:
   name: {{ .Values.metadata.name }}-delete
   annotations:
-    "helm.sh/hook": post-delete
+    "helm.sh/hook": pre-delete
     "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
     "helm.sh/hook-weight": "2"
 rules:
@@ -52,7 +52,7 @@ apiVersion: {{ .Values.rbac.apiGroup }}{{ .Values.rbac.apiVersion }}
 metadata:
   name: {{ .Values.metadata.name }}-delete
   annotations:
-    "helm.sh/hook": post-delete
+    "helm.sh/hook": pre-delete
     "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
     "helm.sh/hook-weight": "3"
 subjects:
@@ -74,7 +74,7 @@ metadata:
     app: {{ .Values.metadata.labelApp }}
   namespace: {{ .Values.metadata.namespace }}
   annotations:
-    "helm.sh/hook": post-delete
+    "helm.sh/hook": pre-delete
     "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
     "helm.sh/hook-weight": "4"
 spec:

--- a/install/charts/templates/delete-clean-up.yaml
+++ b/install/charts/templates/delete-clean-up.yaml
@@ -79,8 +79,6 @@ metadata:
     "helm.sh/hook-weight": "4"
 spec:
   template:
-    metadata:
-      name: {{ .Values.metadata.name }}-pre-delete
     spec:
       serviceAccountName: {{ .Values.rbac.serviceAccount }}-cleanup
       restartPolicy: Never

--- a/install/charts/templates/delete-clean-up.yaml
+++ b/install/charts/templates/delete-clean-up.yaml
@@ -34,4 +34,10 @@ spec:
       containers:
         - name: {{ .Values.metadata.name }}-pre-delete-container
           image: "lachlanevenson/k8s-kubectl"
-          command: ['sh', '-c', 'kubectl delete mutatingwebhookconfigurations karydia-webhook && kubectl delete validatingwebhookconfigurations karydia-webhook && kubectl delete customresourcedefinitions karydianetworkpolicies.karydia.gardener.cloud && kubectl delete customresourcedefinitions karydiaconfigs.karydia.gardener.cloud']
+          command:
+          - kubectl
+          - delete
+          - mutatingwebhookconfigurations/karydia-webhook
+          - validatingwebhookconfigurations/karydia-webhook
+          - customresourcedefinitions/karydianetworkpolicies.karydia.gardener.cloud
+          - customresourcedefinitions/karydiaconfigs.karydia.gardener.cloud

--- a/install/charts/templates/rbac.yaml
+++ b/install/charts/templates/rbac.yaml
@@ -161,15 +161,12 @@ rules:
 - apiGroups: [""]
   resources: ["configmaps"]
   verbs: ["get", "create", "delete"]
-- apiGroups: ["apiextensions.k8s.io"]
-  resources: ["customresourcedefinitions"]
-  verbs: ["delete"]
 - apiGroups: ["admissionregistration.k8s.io"]
   resources: ["validatingwebhookconfigurations"]
-  verbs: ["get", "create", "patch", "delete"]
+  verbs: ["get", "create", "patch"]
 - apiGroups: ["admissionregistration.k8s.io"]
   resources: ["mutatingwebhookconfigurations"]
-  verbs: ["get", "create", "patch", "delete"]
+  verbs: ["get", "create", "patch"]
 
 ---
 

--- a/install/charts/templates/rbac.yaml
+++ b/install/charts/templates/rbac.yaml
@@ -161,12 +161,15 @@ rules:
 - apiGroups: [""]
   resources: ["configmaps"]
   verbs: ["get", "create", "delete"]
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["delete"]
 - apiGroups: ["admissionregistration.k8s.io"]
   resources: ["validatingwebhookconfigurations"]
-  verbs: ["get", "create", "patch"]
+  verbs: ["get", "create", "patch", "delete"]
 - apiGroups: ["admissionregistration.k8s.io"]
   resources: ["mutatingwebhookconfigurations"]
-  verbs: ["get", "create", "patch"]
+  verbs: ["get", "create", "patch", "delete"]
 
 ---
 


### PR DESCRIPTION
## Description
When karydia is deleted via `helm delete --purge karydia` the created CRDs and webhooks should be deleted. This is realized using a `pre-delete`hook.

[Resolves #184]