### PR TITLE
Remove "Clone Repository" instructions from install readme

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -3,17 +3,6 @@ karydia can be installed as a webhook into any Kubernetes cluster.
 
 The installation processes uses [Helm](https://github.com/helm/helm) to get karydia up and running and is split up into two parts.
 
-## Clone Respository
-
-Clone the repository and install the dependencies:
-
-```
-cd ~
-go install github.com/karydia/karydia
-cd ~/go/src/github.com/karydia/karydia
-go install ./...
-```
-
 ## Prepare Helm and Tiller
 First, create a Helm service account and initiate Tiller on the cluster. Thus, run:
 ```


### PR DESCRIPTION
### Description
Remove the "Clone Repository" instructions from the install README, as it is not needed for the installation. It would make sense to create a separate README for the development process.


### Checklist
Before submitting this PR, please make sure:
- [x] you have documented new or changed features
