### PR TITLE
Updated and Tidied Up Permissions

### DIFF
--- a/install/charts/templates/post-install-webhook.yaml
+++ b/install/charts/templates/post-install-webhook.yaml
@@ -14,6 +14,58 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.rbac.serviceAccount }}-post-install
+  namespace: {{ .Values.metadata.namespace }}
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
+    "helm.sh/hook-weight": "1"
+
+---
+
+kind: ClusterRole
+apiVersion: {{ .Values.rbac.apiGroup }}{{ .Values.rbac.apiVersion }}
+metadata:
+  name: {{ .Values.metadata.name }}-post
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
+    "helm.sh/hook-weight": "2"
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get"]
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources: ["validatingwebhookconfigurations"]
+  verbs: ["get", "create"]
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources: ["mutatingwebhookconfigurations"]
+  verbs: ["get", "create"]
+
+---
+
+kind: ClusterRoleBinding
+apiVersion: {{ .Values.rbac.apiGroup }}{{ .Values.rbac.apiVersion }}
+metadata:
+  name: {{ .Values.metadata.name }}-post
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
+    "helm.sh/hook-weight": "3"
+subjects:
+- kind: ServiceAccount
+  namespace: {{ .Values.metadata.namespace }}
+  name: {{ .Values.rbac.serviceAccount }}-post-install
+roleRef:
+  kind: ClusterRole
+  name: {{ .Values.metadata.name }}-post
+  apiGroup: {{ .Values.rbac.apiGroup }}
+
+---
+
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -24,12 +76,13 @@ metadata:
   annotations:
     "helm.sh/hook": post-install
     "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
+    "helm.sh/hook-weight": "4"
 spec:
   template:
     metadata:
       name: {{ .Values.metadata.name }}-post-install
     spec:
-      serviceAccountName: {{ .Values.rbac.serviceAccount }}
+      serviceAccountName: {{ .Values.rbac.serviceAccount }}-post-install
       restartPolicy: OnFailure
       containers:
         - name: {{ .Values.metadata.name }}-post-install-container

--- a/install/charts/templates/post-install-webhook.yaml
+++ b/install/charts/templates/post-install-webhook.yaml
@@ -40,10 +40,10 @@ rules:
   verbs: ["get"]
 - apiGroups: ["admissionregistration.k8s.io"]
   resources: ["validatingwebhookconfigurations"]
-  verbs: ["get", "create"]
+  verbs: ["get", "create", "patch"]
 - apiGroups: ["admissionregistration.k8s.io"]
   resources: ["mutatingwebhookconfigurations"]
-  verbs: ["get", "create"]
+  verbs: ["get", "create", "patch"]
 
 ---
 

--- a/install/charts/templates/rbac.yaml
+++ b/install/charts/templates/rbac.yaml
@@ -180,7 +180,7 @@ metadata:
 rules:
 - apiGroups: ["networking.k8s.io"]
   resources: ["networkpolicies"]
-  verbs: ["watch", "list", "create"]
+  verbs: ["get", "watch", "list", "create", "update", "delete"]
 
 ---
 

--- a/install/charts/templates/rbac.yaml
+++ b/install/charts/templates/rbac.yaml
@@ -25,160 +25,23 @@ metadata:
 kind: ClusterRole
 apiVersion: {{ .Values.rbac.apiGroup }}{{ .Values.rbac.apiVersion }}
 metadata:
-  name: {{ .Values.metadata.name }}-view-kc
-rules:
-- apiGroups: ["karydia.gardener.cloud"]
-  resources: ["karydiaconfigs"]
-  verbs: ["get", "watch", "list"]
-
----
-
-kind: ClusterRole
-apiVersion: {{ .Values.rbac.apiGroup }}{{ .Values.rbac.apiVersion }}
-metadata:
-  name: {{ .Values.metadata.name }}-view-knp
-rules:
-- apiGroups: ["karydia.gardener.cloud"]
-  resources: ["karydianetworkpolicies"]
-  verbs: ["get", "watch", "list"]
-
----
-
-kind: ClusterRole
-apiVersion: {{ .Values.rbac.apiGroup }}{{ .Values.rbac.apiVersion }}
-metadata:
-  name: {{ .Values.metadata.name }}-networkpolicies
-rules:
-- apiGroups: ["networking.k8s.io"]
-  resources: ["networkpolicies"]
-  verbs: ["get", "watch", "list", "create", "patch", "update", "delete"]
-
----
-
-kind: ClusterRoleBinding
-apiVersion: {{ .Values.rbac.apiGroup }}{{ .Values.rbac.apiVersion }}
-metadata:
-  name: {{ .Values.metadata.name }}-view
-subjects:
-- kind: ServiceAccount
-  namespace: {{ .Values.metadata.namespace }}
-  name: {{ .Values.rbac.serviceAccount }}
-roleRef:
-  kind: ClusterRole
-  name: view
-  apiGroup: {{ .Values.rbac.apiGroup }}
-
----
-
-kind: ClusterRoleBinding
-apiVersion: {{ .Values.rbac.apiGroup }}{{ .Values.rbac.apiVersion }}
-metadata:
-  name: {{ .Values.metadata.name }}-networkpolicies
-subjects:
-- kind: ServiceAccount
-  namespace: {{ .Values.metadata.namespace }}
-  name: {{ .Values.rbac.serviceAccount }}
-roleRef:
-  kind: ClusterRole
-  name: {{ .Values.metadata.name }}-networkpolicies
-  apiGroup: {{ .Values.rbac.apiGroup }}
-
----
-
-kind: ClusterRoleBinding
-apiVersion: {{ .Values.rbac.apiGroup }}{{ .Values.rbac.apiVersion }}
-metadata:
-  name: {{ .Values.metadata.name }}-view-kc
-subjects:
-- kind: ServiceAccount
-  namespace: {{ .Values.metadata.namespace }}
-  name: {{ .Values.rbac.serviceAccount }}
-roleRef:
-  kind: ClusterRole
-  name: {{ .Values.metadata.name }}-view-kc
-  apiGroup: {{ .Values.rbac.apiGroup }}
-
----
-
-kind: ClusterRoleBinding
-apiVersion: {{ .Values.rbac.apiGroup }}{{ .Values.rbac.apiVersion }}
-metadata:
-  name: {{ .Values.metadata.name }}-view-knp
-subjects:
-- kind: ServiceAccount
-  namespace: {{ .Values.metadata.namespace }}
-  name: {{ .Values.rbac.serviceAccount }}
-roleRef:
-  kind: ClusterRole
-  name: {{ .Values.metadata.name }}-view-knp
-  apiGroup: {{ .Values.rbac.apiGroup }}
-
----
-
-kind: ClusterRole
-apiVersion: {{ .Values.rbac.apiGroup }}{{ .Values.rbac.apiVersion }}
-metadata:
-  name: {{ .Values.metadata.name }}-view-roles
-rules:
-- apiGroups: ["rbac.authorization.k8s.io"]
-  resources: ["clusterroles", "clusterrolebindings", "roles", "rolebindings"]
-  verbs: ["list"]
-
----
-
-kind: ClusterRoleBinding
-apiVersion: {{ .Values.rbac.apiGroup }}{{ .Values.rbac.apiVersion }}
-metadata:
-  name: {{ .Values.metadata.name }}-view-roles
-subjects:
-- kind: ServiceAccount
-  namespace: {{ .Values.metadata.namespace }}
-  name: {{ .Values.rbac.serviceAccount }}
-roleRef:
-  kind: ClusterRole
-  name: {{ .Values.metadata.name }}-view-roles
-  apiGroup: {{ .Values.rbac.apiGroup }}
-
----
-
-kind: ClusterRole
-apiVersion: {{ .Values.rbac.apiGroup }}{{ .Values.rbac.apiVersion }}
-metadata:
-  name: {{ .Values.metadata.name }}-installer
+  name: {{ .Values.metadata.name }}-init
 rules:
 - apiGroups: [""]
-  resources: ["pods"]
-  verbs: ["get", "watch", "list"]
-- apiGroups: ["certificates.k8s.io"]
-  resources: ["certificatesigningrequests"]
-  verbs: ["create", "delete", "get"]
-- apiGroups: ["certificates.k8s.io"]
-  resources: ["certificatesigningrequests/approval"]
-  verbs: ["update"]
-- apiGroups: [""]
-  resources: ["secrets"]
-  verbs: ["get", "create", "patch"]
-- apiGroups: [""]
-  resources: ["configmaps"]
-  verbs: ["get", "create", "delete"]
-- apiGroups: ["admissionregistration.k8s.io"]
-  resources: ["validatingwebhookconfigurations"]
-  verbs: ["get", "create", "patch"]
-- apiGroups: ["admissionregistration.k8s.io"]
-  resources: ["mutatingwebhookconfigurations"]
-  verbs: ["get", "create", "patch"]
+  resources: [""]
+  verbs: [""]
 
 ---
 
 kind: ClusterRoleBinding
 apiVersion: {{ .Values.rbac.apiGroup }}{{ .Values.rbac.apiVersion }}
 metadata:
-  name: install-{{ .Values.metadata.name }}
+  name: init-{{ .Values.metadata.name }}
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.rbac.serviceAccount }}
   namespace: {{ .Values.metadata.namespace }}
 roleRef:
   kind: ClusterRole
-  name: {{ .Values.metadata.name }}-installer
+  name: {{ .Values.metadata.name }}-init
   apiGroup: {{ .Values.rbac.apiGroup }}

--- a/install/charts/templates/rbac.yaml
+++ b/install/charts/templates/rbac.yaml
@@ -22,14 +22,24 @@ metadata:
 
 ---
 
+# Init Container
+# => Create and approve Certificate Signing Requests (CSR)
+# => Create TLS secret
+
 kind: ClusterRole
 apiVersion: {{ .Values.rbac.apiGroup }}{{ .Values.rbac.apiVersion }}
 metadata:
   name: {{ .Values.metadata.name }}-init
 rules:
+- apiGroups: ["certificates.k8s.io"]
+  resources: ["certificatesigningrequests"]
+  verbs: ["create", "delete", "get"]
+- apiGroups: ["certificates.k8s.io"]
+  resources: ["certificatesigningrequests/approval"]
+  verbs: ["update"]
 - apiGroups: [""]
-  resources: [""]
-  verbs: [""]
+  resources: ["secrets"]
+  verbs: ["create", "get", "patch"]
 
 ---
 
@@ -44,4 +54,145 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: {{ .Values.metadata.name }}-init
+  apiGroup: {{ .Values.rbac.apiGroup }}
+
+---
+
+# Karydia Deployment
+# => View Namespaces
+
+kind: ClusterRole
+apiVersion: {{ .Values.rbac.apiGroup }}{{ .Values.rbac.apiVersion }}
+metadata:
+  name: {{ .Values.metadata.name }}-view
+rules:
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["get", "list", "watch"]
+
+---
+
+kind: ClusterRoleBinding
+apiVersion: {{ .Values.rbac.apiGroup }}{{ .Values.rbac.apiVersion }}
+metadata:
+  name: {{ .Values.metadata.name }}-view
+subjects:
+- kind: ServiceAccount
+  namespace: {{ .Values.metadata.namespace }}
+  name: {{ .Values.rbac.serviceAccount }}
+roleRef:
+  kind: ClusterRole
+  name: {{ .Values.metadata.name }}-view
+  apiGroup: {{ .Values.rbac.apiGroup }}
+
+---
+
+# => View karydia Config
+
+kind: ClusterRole
+apiVersion: {{ .Values.rbac.apiGroup }}{{ .Values.rbac.apiVersion }}
+metadata:
+  name: {{ .Values.metadata.name }}-karydiaconfig
+rules:
+- apiGroups: ["karydia.gardener.cloud"]
+  resources: ["karydiaconfigs"]
+  verbs: ["get", "watch", "list"]
+
+---
+
+kind: ClusterRoleBinding
+apiVersion: {{ .Values.rbac.apiGroup }}{{ .Values.rbac.apiVersion }}
+metadata:
+  name: {{ .Values.metadata.name }}-karydiaconfig
+subjects:
+- kind: ServiceAccount
+  namespace: {{ .Values.metadata.namespace }}
+  name: {{ .Values.rbac.serviceAccount }}
+roleRef:
+  kind: ClusterRole
+  name: {{ .Values.metadata.name }}-karydiaconfig
+  apiGroup: {{ .Values.rbac.apiGroup }}
+
+---
+
+# => View karydia Network Policies
+
+kind: ClusterRole
+apiVersion: {{ .Values.rbac.apiGroup }}{{ .Values.rbac.apiVersion }}
+metadata:
+  name: {{ .Values.metadata.name }}-karydianetworkpolicies
+rules:
+- apiGroups: ["karydia.gardener.cloud"]
+  resources: ["karydianetworkpolicies"]
+  verbs: ["get", "watch", "list"]
+
+---
+
+kind: ClusterRoleBinding
+apiVersion: {{ .Values.rbac.apiGroup }}{{ .Values.rbac.apiVersion }}
+metadata:
+  name: {{ .Values.metadata.name }}-karydianetworkpolicies
+subjects:
+- kind: ServiceAccount
+  namespace: {{ .Values.metadata.namespace }}
+  name: {{ .Values.rbac.serviceAccount }}
+roleRef:
+  kind: ClusterRole
+  name: {{ .Values.metadata.name }}-karydianetworkpolicies
+  apiGroup: {{ .Values.rbac.apiGroup }}
+
+---
+
+# => View (Cluster-)Roles and Bindings
+
+kind: ClusterRole
+apiVersion: {{ .Values.rbac.apiGroup }}{{ .Values.rbac.apiVersion }}
+metadata:
+  name: {{ .Values.metadata.name }}-roles
+rules:
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["clusterroles", "clusterrolebindings", "roles", "rolebindings"]
+  verbs: ["list"]
+
+---
+
+kind: ClusterRoleBinding
+apiVersion: {{ .Values.rbac.apiGroup }}{{ .Values.rbac.apiVersion }}
+metadata:
+  name: {{ .Values.metadata.name }}-roles
+subjects:
+- kind: ServiceAccount
+  namespace: {{ .Values.metadata.namespace }}
+  name: {{ .Values.rbac.serviceAccount }}
+roleRef:
+  kind: ClusterRole
+  name: {{ .Values.metadata.name }}-roles
+  apiGroup: {{ .Values.rbac.apiGroup }}
+
+---
+
+# => Control Networkpolicies
+
+kind: ClusterRole
+apiVersion: {{ .Values.rbac.apiGroup }}{{ .Values.rbac.apiVersion }}
+metadata:
+  name: {{ .Values.metadata.name }}-networkpolicies
+rules:
+- apiGroups: ["networking.k8s.io"]
+  resources: ["networkpolicies"]
+  verbs: ["get", "watch", "list", "create", "patch", "update", "delete"]
+
+---
+
+kind: ClusterRoleBinding
+apiVersion: {{ .Values.rbac.apiGroup }}{{ .Values.rbac.apiVersion }}
+metadata:
+  name: {{ .Values.metadata.name }}-networkpolicies
+subjects:
+- kind: ServiceAccount
+  namespace: {{ .Values.metadata.namespace }}
+  name: {{ .Values.rbac.serviceAccount }}
+roleRef:
+  kind: ClusterRole
+  name: {{ .Values.metadata.name }}-networkpolicies
   apiGroup: {{ .Values.rbac.apiGroup }}

--- a/install/charts/templates/rbac.yaml
+++ b/install/charts/templates/rbac.yaml
@@ -64,7 +64,7 @@ roleRef:
 kind: ClusterRole
 apiVersion: {{ .Values.rbac.apiGroup }}{{ .Values.rbac.apiVersion }}
 metadata:
-  name: {{ .Values.metadata.name }}-view
+  name: {{ .Values.metadata.name }}-namespaces
 rules:
 - apiGroups: [""]
   resources: ["namespaces"]
@@ -75,14 +75,14 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: {{ .Values.rbac.apiGroup }}{{ .Values.rbac.apiVersion }}
 metadata:
-  name: {{ .Values.metadata.name }}-view
+  name: {{ .Values.metadata.name }}-namespaces
 subjects:
 - kind: ServiceAccount
   namespace: {{ .Values.metadata.namespace }}
   name: {{ .Values.rbac.serviceAccount }}
 roleRef:
   kind: ClusterRole
-  name: {{ .Values.metadata.name }}-view
+  name: {{ .Values.metadata.name }}-namespaces
   apiGroup: {{ .Values.rbac.apiGroup }}
 
 ---
@@ -180,7 +180,7 @@ metadata:
 rules:
 - apiGroups: ["networking.k8s.io"]
   resources: ["networkpolicies"]
-  verbs: ["get", "watch", "list", "create", "patch", "update", "delete"]
+  verbs: ["watch", "list", "create"]
 
 ---
 

--- a/install/charts/templates/workaround-annotate-kube-system-namespace.yaml
+++ b/install/charts/templates/workaround-annotate-kube-system-namespace.yaml
@@ -21,6 +21,52 @@
 #   identify 'kube-system' namespaces which used this workaround for cleaning
 #   things up later on.
 
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.rbac.serviceAccount }}-workaround
+  namespace: {{ .Values.metadata.namespace }}
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
+    "helm.sh/hook-weight": "1"
+
+---
+
+kind: ClusterRole
+apiVersion: {{ .Values.rbac.apiGroup }}{{ .Values.rbac.apiVersion }}
+metadata:
+  name: {{ .Values.metadata.name }}-pre-install
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
+    "helm.sh/hook-weight": "2"
+rules:
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["get", "patch"]
+
+---
+
+kind: ClusterRoleBinding
+apiVersion: {{ .Values.rbac.apiGroup }}{{ .Values.rbac.apiVersion }}
+metadata:
+  name: {{ .Values.metadata.name }}-pre-install
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
+    "helm.sh/hook-weight": "3"
+subjects:
+- kind: ServiceAccount
+  namespace: {{ .Values.metadata.namespace }}
+  name: {{ .Values.rbac.serviceAccount }}-workaround
+roleRef:
+  kind: ClusterRole
+  name: {{ .Values.metadata.name }}-pre-install
+  apiGroup: {{ .Values.rbac.apiGroup }}
+
+---
+
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -31,10 +77,11 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+    "helm.sh/hook-weight": "4"
 spec:
   template:
     spec:
-      serviceAccountName: tiller
+      serviceAccountName: {{ .Values.rbac.serviceAccount }}-workaround
       restartPolicy: Never
       containers:
       - name: {{ .Values.metadata.name }}-annotater


### PR DESCRIPTION
### Description
This PR updates the permission used for karydia. It especially focus on splitting up the unified "serviceAccount" in multiple ones used during the installation, production and deletion. This ensure the principle of least privilege.

Moreover, I checked all currently used permissions and updated them accordingly to the usage by karydia (based on what errors occurred during installation, production and testing).

It would be great, if everyone who maintains one feature of karydia that is linked to special permissions reviews these changes and checks if everything is still working as intended.

Resolves #202.


### Checklist
Before submitting this PR, please make sure:
- [x] your code builds clean with `make`
- [x] your code lets succeed unit tests with `make test`
- [x] your code lets succeed integration tests
