### PR TITLE
Add option to enforce specified default karydia config

### DIFF
--- a/cli/cmd/runserver.go
+++ b/cli/cmd/runserver.go
@@ -120,6 +120,7 @@ func runserverFunc(cmd *cobra.Command, args []string) {
 		log.Fatalln("Failed to load karydia config:", err)
 	}
 	log.Infoln("KarydiaConfig Name:", karydiaConfig.Name)
+	log.Infoln("KarydiaConfig Enforcement:", karydiaConfig.Spec.Enforcement)
 	log.Infoln("KarydiaConfig AutomountServiceAccountToken:", karydiaConfig.Spec.AutomountServiceAccountToken)
 	log.Infoln("KarydiaConfig SeccompProfile:", karydiaConfig.Spec.SeccompProfile)
 	log.Infoln("KarydiaConfig NetworkPolicy:", karydiaConfig.Spec.NetworkPolicy)
@@ -165,7 +166,7 @@ func runserverFunc(cmd *cobra.Command, args []string) {
 		kubeInformerFactory = kubeinformers.NewSharedInformerFactory(kubeClientset, resyncInterval)
 		namespaceInformer := kubeInformerFactory.Core().V1().Namespaces()
 		networkPolicyInformer := kubeInformerFactory.Networking().V1().NetworkPolicies()
-		reconciler = controller.NewNetworkpolicyReconciler(kubeClientset, karydiaClientset, networkPolicyInformer, namespaceInformer, defaultNetworkPolicies, karydiaConfig.Spec.NetworkPolicy, viper.GetStringSlice("default-network-policy-excludes"))
+		reconciler = controller.NewNetworkpolicyReconciler(kubeClientset, karydiaClientset, networkPolicyInformer, namespaceInformer, defaultNetworkPolicies, karydiaConfig.Spec.Enforcement, karydiaConfig.Spec.NetworkPolicy, viper.GetStringSlice("default-network-policy-excludes"))
 		karydiaControllers = append(karydiaControllers, reconciler)
 	}
 

--- a/install/charts/templates/config.yaml
+++ b/install/charts/templates/config.yaml
@@ -21,6 +21,7 @@ metadata:
     app: {{ .Values.metadata.labelApp }}
   name: {{ .Values.config.name }}
 spec:
+  enforcement: {{ .Values.config.enforcement }}
   automountServiceAccountToken: "{{ .Values.config.automountServiceAccountToken }}"
   seccompProfile: "{{ .Values.config.seccompProfile }}"
   networkPolicy: "{{ .Values.config.networkPolicy }}"

--- a/install/charts/templates/crd-config.yaml
+++ b/install/charts/templates/crd-config.yaml
@@ -36,6 +36,8 @@ spec:
       properties:
         spec:
           properties:
+            enforcement:
+              type: boolean
             automountServiceAccountToken:
               type: string
             seccompProfile:

--- a/install/charts/values.yaml
+++ b/install/charts/values.yaml
@@ -19,6 +19,7 @@ features:
   karydiaAdmission: true
 config:
   name: "karydia-config"
+  enforcement: false
   automountServiceAccountToken: "change-default"
   seccompProfile: "runtime/default"
   networkPolicy: "karydia-default-network-policy"

--- a/pkg/admission/karydia/admission_pod.go
+++ b/pkg/admission/karydia/admission_pod.go
@@ -59,7 +59,7 @@ func (k *KarydiaAdmission) validatePod(pod *corev1.Pod, ns *corev1.Namespace) *v
 func (k *KarydiaAdmission) getSeccompProfileSetting(ns *corev1.Namespace) Setting {
 	var src string
 	seccompProfile, annotated := ns.ObjectMeta.Annotations["karydia.gardener.cloud/seccompProfile"]
-	if annotated {
+	if annotated && k.karydiaConfig != nil && k.karydiaConfig.Spec.Enforcement == false {
 		src = "namespace"
 	} else if k.karydiaConfig != nil {
 		seccompProfile = k.karydiaConfig.Spec.SeccompProfile
@@ -71,7 +71,7 @@ func (k *KarydiaAdmission) getSeccompProfileSetting(ns *corev1.Namespace) Settin
 func (k *KarydiaAdmission) getSecurityContextSetting(ns *corev1.Namespace) Setting {
 	var src string
 	securityContext, annotated := ns.ObjectMeta.Annotations["karydia.gardener.cloud/podSecurityContext"]
-	if annotated {
+	if annotated && k.karydiaConfig != nil && k.karydiaConfig.Spec.Enforcement == false {
 		src = "namespace"
 	} else if k.karydiaConfig != nil {
 		securityContext = k.karydiaConfig.Spec.PodSecurityContext

--- a/pkg/admission/karydia/admission_service_account.go
+++ b/pkg/admission/karydia/admission_service_account.go
@@ -51,7 +51,7 @@ func (k *KarydiaAdmission) validateServiceAccount(sAcc *corev1.ServiceAccount, n
 func (k *KarydiaAdmission) getAutomountServiceAccountTokenSetting(ns *corev1.Namespace) Setting {
 	automountServiceAccountToken, annotated := ns.ObjectMeta.Annotations["karydia.gardener.cloud/automountServiceAccountToken"]
 	src := "namespace"
-	if !annotated {
+	if !annotated || (k.karydiaConfig != nil && k.karydiaConfig.Spec.Enforcement == true) {
 		automountServiceAccountToken = k.karydiaConfig.Spec.AutomountServiceAccountToken
 		src = "config"
 	}

--- a/pkg/apis/karydia/v1alpha1/types.go
+++ b/pkg/apis/karydia/v1alpha1/types.go
@@ -34,6 +34,10 @@ type KarydiaConfig struct {
 }
 
 type KarydiaConfigSpec struct {
+	// Enforcement can be used to enforce this default karydia configuration
+	// and disable the "opt-out via annotation" functionality
+	Enforcement bool `json:"enforcement"`
+
 	// AutomountServiceAccountToken can be used to restrict auto-mounting
 	// of service account tokens by default
 	AutomountServiceAccountToken string `json:"automountServiceAccountToken"`

--- a/pkg/controller/config_reconciler.go
+++ b/pkg/controller/config_reconciler.go
@@ -257,6 +257,7 @@ func (reconciler *ConfigReconciler) UpdateConfig(karydiaConfig v1alpha1.KarydiaC
 		}
 	}
 	reconciler.log.Infoln("KarydiaConfig Name:", karydiaConfig.Name)
+	reconciler.log.Infoln("KarydiaConfig Enforcement:", karydiaConfig.Spec.Enforcement)
 	reconciler.log.Infoln("KarydiaConfig AutomountServiceAccountToken:", karydiaConfig.Spec.AutomountServiceAccountToken)
 	reconciler.log.Infoln("KarydiaConfig SeccompProfile:", karydiaConfig.Spec.SeccompProfile)
 	reconciler.log.Infoln("KarydiaConfig NetworkPolicy:", karydiaConfig.Spec.NetworkPolicy)

--- a/pkg/controller/networkpolicy_reconciler_test.go
+++ b/pkg/controller/networkpolicy_reconciler_test.go
@@ -92,7 +92,7 @@ func (f *fixture) newReconciler() (*NetworkpolicyReconciler, kubeinformers.Share
 
 	k8sI := kubeinformers.NewSharedInformerFactory(f.kubeclient, noResyncPeriodFunc())
 
-	reconciler := NewNetworkpolicyReconciler(f.kubeclient, f.karydiaClient, k8sI.Networking().V1().NetworkPolicies(), k8sI.Core().V1().Namespaces(), f.defaultNetworkPolicies, "karydia-default-network-policy", f.namespaceExclude)
+	reconciler := NewNetworkpolicyReconciler(f.kubeclient, f.karydiaClient, k8sI.Networking().V1().NetworkPolicies(), k8sI.Core().V1().Namespaces(), f.defaultNetworkPolicies, false, "karydia-default-network-policy", f.namespaceExclude)
 
 	reconciler.networkPoliciesSynced = alwaysReady
 	reconciler.namespacesSynced = alwaysReady


### PR DESCRIPTION
<!-- Thanks for sending a PR -->

### Description
<!-- Feature description or reference to fixed issue -->
Add option to enforce specified default karydia config and disable the "opt-out via annotation" functionality.

### Checklist
Before submitting this PR, please make sure:
- [x] your code builds clean with `make`
- [x] your code lets succeed unit tests with `make test`
- [x] your code lets succeed integration tests
<!-- Please delete options that are not relevant -->
