### PR TITLE
Withdraw 'kube-system' namespace from enforcement

### DIFF
--- a/install/charts/templates/workaround-annotate-kube-system-namespace.yaml
+++ b/install/charts/templates/workaround-annotate-kube-system-namespace.yaml
@@ -48,3 +48,4 @@ spec:
         - karydia.gardener.cloud/workaroundForIssue=183
         - karydia.gardener.cloud/seccompProfile=unconfined
         - karydia.gardener.cloud/podSecurityContext=none
+        - karydia.gardener.cloud/automountServiceAccountToken=no-change

--- a/pkg/admission/karydia/admission_pod.go
+++ b/pkg/admission/karydia/admission_pod.go
@@ -59,7 +59,7 @@ func (k *KarydiaAdmission) validatePod(pod *corev1.Pod, ns *corev1.Namespace) *v
 func (k *KarydiaAdmission) getSeccompProfileSetting(ns *corev1.Namespace) Setting {
 	var src string
 	seccompProfile, annotated := ns.ObjectMeta.Annotations["karydia.gardener.cloud/seccompProfile"]
-	if annotated && k.karydiaConfig != nil && k.karydiaConfig.Spec.Enforcement == false {
+	if annotated && (ns.Name == "kube-system" || (k.karydiaConfig != nil && k.karydiaConfig.Spec.Enforcement == false)) {
 		src = "namespace"
 	} else if k.karydiaConfig != nil {
 		seccompProfile = k.karydiaConfig.Spec.SeccompProfile
@@ -71,7 +71,7 @@ func (k *KarydiaAdmission) getSeccompProfileSetting(ns *corev1.Namespace) Settin
 func (k *KarydiaAdmission) getSecurityContextSetting(ns *corev1.Namespace) Setting {
 	var src string
 	securityContext, annotated := ns.ObjectMeta.Annotations["karydia.gardener.cloud/podSecurityContext"]
-	if annotated && k.karydiaConfig != nil && k.karydiaConfig.Spec.Enforcement == false {
+	if annotated && (ns.Name == "kube-system" || (k.karydiaConfig != nil && k.karydiaConfig.Spec.Enforcement == false)) {
 		src = "namespace"
 	} else if k.karydiaConfig != nil {
 		securityContext = k.karydiaConfig.Spec.PodSecurityContext

--- a/pkg/admission/karydia/admission_service_account.go
+++ b/pkg/admission/karydia/admission_service_account.go
@@ -51,7 +51,7 @@ func (k *KarydiaAdmission) validateServiceAccount(sAcc *corev1.ServiceAccount, n
 func (k *KarydiaAdmission) getAutomountServiceAccountTokenSetting(ns *corev1.Namespace) Setting {
 	automountServiceAccountToken, annotated := ns.ObjectMeta.Annotations["karydia.gardener.cloud/automountServiceAccountToken"]
 	src := "namespace"
-	if !annotated || (k.karydiaConfig != nil && k.karydiaConfig.Spec.Enforcement == true) {
+	if !annotated || (ns.Name != "kube-system" && k.karydiaConfig != nil && k.karydiaConfig.Spec.Enforcement == true) {
 		automountServiceAccountToken = k.karydiaConfig.Spec.AutomountServiceAccountToken
 		src = "config"
 	}


### PR DESCRIPTION
<!-- Thanks for sending a PR -->

### Description
<!-- Feature description or reference to fixed issue -->
Withdraw 'kube-system' namespace from enforcement.

### Checklist
Before submitting this PR, please make sure:
- [x] your code builds clean with `make`
- [x] your code lets succeed unit tests with `make test`
- [x] your code lets succeed integration tests
<!-- Please delete options that are not relevant -->
