### PR TITLE
User kubeconfig example

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 **/.*.sw[po]
+**/.user.kube/
 **/.idea/
 
 .dockerignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .*.sw[po]
+.user.kube/
 .idea/
 
 /bin/

--- a/scripts/create-user-kubeconfig-example
+++ b/scripts/create-user-kubeconfig-example
@@ -46,7 +46,7 @@ token=$(kubectl -n "${namespace}" get secret "${secret}" -o jsonpath='{.data.tok
 kubectl -n "${namespace}" get secret "${secret}" -o jsonpath='{.data.ca\.crt}' | base64 --decode > ${cacrtfile}
 
 # Restrict user's permissions (example)
-cat <<EOF | kubectl create -f -
+cat <<EOF | kubectl apply -f -
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/scripts/create-user-kubeconfig-example
+++ b/scripts/create-user-kubeconfig-example
@@ -45,6 +45,7 @@ secret=$(kubectl -n "${namespace}" get serviceaccount "${user}" -o jsonpath='{.s
 token=$(kubectl -n "${namespace}" get secret "${secret}" -o jsonpath='{.data.token}' | base64 --decode)
 kubectl -n "${namespace}" get secret "${secret}" -o jsonpath='{.data.ca\.crt}' | base64 --decode > ${cacrtfile}
 
+
 # Restrict user's permissions (example)
 cat <<EOF | kubectl apply -f -
 apiVersion: rbac.authorization.k8s.io/v1
@@ -53,9 +54,87 @@ metadata:
   name: core-developer
 rules:
 - apiGroups: [""]
-  resources: ["configmaps", "events", "limitranges", "persistentvolumeclaims", "persistentvolumes", "pods", "podtemplates", "secrets", "services"]
+  resources: ["configmaps", "events", "limitranges", "persistentvolumeclaims", "persistentvolumes", "pods", "pods/attach", "pods/exec", "pods/log", "pods/portforward", "podtemplates", "replicationcontrollers", "secrets", "services"]
   verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
 EOF
+
+cat <<EOF | kubectl apply -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: batch-developer
+rules:
+- apiGroups: ["batch"]
+  resources: ["cronjobs", "jobs"]
+  verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+EOF
+
+cat <<EOF | kubectl apply -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: autoscaling-developer
+rules:
+- apiGroups: ["autoscaling"]
+  resources: ["horizontalpodautoscalers"]
+  verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+EOF
+
+cat <<EOF | kubectl apply -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: policy-developer
+rules:
+- apiGroups: ["policy"]
+  resources: ["poddisruptionbudgets", "podsecuritypolicies"]
+  verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+EOF
+
+cat <<EOF | kubectl apply -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: app-developer
+rules:
+- apiGroups: ["apps"]
+  resources: ["controllerrevisions", "daemonsets", "deployments", "replicasets", "statefulsets"]
+  verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+EOF
+
+cat <<EOF | kubectl apply -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: extension-developer
+rules:
+- apiGroups: ["extensions"]
+  resources: ["daemonsets", "deployments", "ingresses", "networkpolicies", "podsecuritypolicies", "replicasets"]
+  verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+EOF
+
+cat <<EOF | kubectl apply -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: k8sioevent-developer
+rules:
+- apiGroups: ["events.k8s.io"]
+  resources: ["events"]
+  verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+EOF
+
+cat <<EOF | kubectl apply -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: k8sionetworking-developer
+rules:
+- apiGroups: ["networking.k8s.io"]
+  resources: ["ingresses", "networkpolicies"]
+  verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+EOF
+
 
 cat <<EOF | kubectl create -f -
 apiVersion: rbac.authorization.k8s.io/v1
@@ -72,6 +151,119 @@ roleRef:
   name: core-developer
   apiGroup: rbac.authorization.k8s.io
 EOF
+
+cat <<EOF | kubectl create -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: ${namespace}
+  name: develop-batch
+subjects:
+- kind: ServiceAccount
+  namespace: ${namespace}
+  name: ${user}
+roleRef:
+  kind: ClusterRole
+  name: batch-developer
+  apiGroup: rbac.authorization.k8s.io
+EOF
+
+cat <<EOF | kubectl create -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: ${namespace}
+  name: develop-autoscaling
+subjects:
+- kind: ServiceAccount
+  namespace: ${namespace}
+  name: ${user}
+roleRef:
+  kind: ClusterRole
+  name: autoscaling-developer
+  apiGroup: rbac.authorization.k8s.io
+EOF
+
+cat <<EOF | kubectl create -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: ${namespace}
+  name: develop-policy
+subjects:
+- kind: ServiceAccount
+  namespace: ${namespace}
+  name: ${user}
+roleRef:
+  kind: ClusterRole
+  name: policy-developer
+  apiGroup: rbac.authorization.k8s.io
+EOF
+
+cat <<EOF | kubectl create -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: ${namespace}
+  name: develop-app
+subjects:
+- kind: ServiceAccount
+  namespace: ${namespace}
+  name: ${user}
+roleRef:
+  kind: ClusterRole
+  name: app-developer
+  apiGroup: rbac.authorization.k8s.io
+EOF
+
+cat <<EOF | kubectl create -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: ${namespace}
+  name: develop-extension
+subjects:
+- kind: ServiceAccount
+  namespace: ${namespace}
+  name: ${user}
+roleRef:
+  kind: ClusterRole
+  name: extension-developer
+  apiGroup: rbac.authorization.k8s.io
+EOF
+
+cat <<EOF | kubectl create -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: ${namespace}
+  name: develop-k8sioevent
+subjects:
+- kind: ServiceAccount
+  namespace: ${namespace}
+  name: ${user}
+roleRef:
+  kind: ClusterRole
+  name: k8sioevent-developer
+  apiGroup: rbac.authorization.k8s.io
+EOF
+
+cat <<EOF | kubectl create -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: ${namespace}
+  name: develop-k8sionetworking
+subjects:
+- kind: ServiceAccount
+  namespace: ${namespace}
+  name: ${user}
+roleRef:
+  kind: ClusterRole
+  name: k8sionetworking-developer
+  apiGroup: rbac.authorization.k8s.io
+EOF
+
 
 # Create user's kubeconfig
 kubeconfigfile=${outdir}/${usrctx}.kubeconfig

--- a/scripts/create-user-kubeconfig-example
+++ b/scripts/create-user-kubeconfig-example
@@ -33,15 +33,19 @@ cluster=$(kubectl config view -o jsonpath="{.contexts[?(@.name==\"${context}\")]
 server=$(kubectl config view -o jsonpath="{.clusters[?(@.name==\"${cluster}\")].cluster.server}")
 usrctx="${context}-user-${user}"
 
+# Create project namespace (example)
+namespace='production'
+kubectl create namespace "${namespace}"
+
 # Create & collect user information
 cacrtfile=${outdir}/${usrctx}.ca.crt
 mkdir -p ${outdir}
-kubectl create serviceaccount "${user}"
-secret=$(kubectl get serviceaccount "${user}" -o jsonpath='{.secrets[0].name}')
-token=$(kubectl get secret "${secret}" -o jsonpath='{.data.token}' | base64 --decode)
-kubectl get secret "${secret}" -o jsonpath='{.data.ca\.crt}' | base64 --decode > ${cacrtfile}
+kubectl -n "${namespace}" create serviceaccount "${user}"
+secret=$(kubectl -n "${namespace}" get serviceaccount "${user}" -o jsonpath='{.secrets[0].name}')
+token=$(kubectl -n "${namespace}" get secret "${secret}" -o jsonpath='{.data.token}' | base64 --decode)
+kubectl -n "${namespace}" get secret "${secret}" -o jsonpath='{.data.ca\.crt}' | base64 --decode > ${cacrtfile}
 
-# Restrict user's permissions
+# Restrict user's permissions (example)
 cat <<EOF | kubectl create -f -
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -67,6 +71,7 @@ KUBECONFIG=${kubeconfigfile} kubectl config set-credentials "${usrctx}" \
   --token="${token}"
 KUBECONFIG=${kubeconfigfile} kubectl config set-context "${usrctx}" \
   --cluster="${cluster}" \
+  --namespace="${namespace}" \
   --user="${usrctx}"
 KUBECONFIG=${kubeconfigfile} kubectl config use-context "${usrctx}"
 

--- a/scripts/create-user-kubeconfig-example
+++ b/scripts/create-user-kubeconfig-example
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+# Copyright (C) 2019 SAP SE or an SAP affiliate company. All rights reserved.
+# This file is licensed under the Apache Software License, v. 2 except as
+# noted otherwise in the LICENSE file.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Parameter(s)
+if [[ -z "$1" ]]
+then
+  echo "Usage: $0 USERNAME"
+  exit 1
+fi
+user=$1
+outdir=./.user.kube
+echo 'Execution...'
+echo
+
+# Collect cluster information
+context=$(kubectl config current-context)
+cluster=$(kubectl config view -o jsonpath="{.contexts[?(@.name==\"${context}\")].context.cluster}")
+server=$(kubectl config view -o jsonpath="{.clusters[?(@.name==\"${cluster}\")].cluster.server}")
+usrctx="${context}-user-${user}"
+
+# Create & collect user information
+cacrtfile=${outdir}/${usrctx}.ca.crt
+mkdir -p ${outdir}
+kubectl create serviceaccount "${user}"
+secret=$(kubectl get serviceaccount "${user}" -o jsonpath='{.secrets[0].name}')
+token=$(kubectl get secret "${secret}" -o jsonpath='{.data.token}' | base64 --decode)
+kubectl get secret "${secret}" -o jsonpath='{.data.ca\.crt}' | base64 --decode > ${cacrtfile}
+
+# Restrict user's permissions
+cat <<EOF | kubectl create -f -
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: view-${user}-global
+subjects:
+- kind: ServiceAccount
+  name: ${user}
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: view
+  apiGroup: rbac.authorization.k8s.io
+EOF
+
+# Create user's kubeconfig
+kubeconfigfile=${outdir}/${usrctx}.kubeconfig
+KUBECONFIG=${kubeconfigfile} kubectl config set-cluster "${cluster}" \
+  --embed-certs=true \
+  --certificate-authority="${cacrtfile}" \
+  --server="${server}"
+KUBECONFIG=${kubeconfigfile} kubectl config set-credentials "${usrctx}" \
+  --token="${token}"
+KUBECONFIG=${kubeconfigfile} kubectl config set-context "${usrctx}" \
+  --cluster="${cluster}" \
+  --user="${usrctx}"
+KUBECONFIG=${kubeconfigfile} kubectl config use-context "${usrctx}"
+
+# Clean up
+rm -f ${cacrtfile}
+
+echo
+echo "Done. Test with:"
+echo "export KUBECONFIG=${kubeconfigfile}"
+

--- a/scripts/create-user-kubeconfig-example
+++ b/scripts/create-user-kubeconfig-example
@@ -47,17 +47,29 @@ kubectl -n "${namespace}" get secret "${secret}" -o jsonpath='{.data.ca\.crt}' |
 
 # Restrict user's permissions (example)
 cat <<EOF | kubectl apply -f -
-kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
 metadata:
-  name: view-${user}-global
+  name: core-developer
+rules:
+- apiGroups: [""]
+  resources: ["configmaps", "events", "limitranges", "persistentvolumeclaims", "persistentvolumes", "pods", "podtemplates", "secrets", "services"]
+  verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+EOF
+
+cat <<EOF | kubectl create -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: ${namespace}
+  name: develop-core
 subjects:
 - kind: ServiceAccount
+  namespace: ${namespace}
   name: ${user}
-  namespace: default
 roleRef:
   kind: ClusterRole
-  name: view
+  name: core-developer
   apiGroup: rbac.authorization.k8s.io
 EOF
 


### PR DESCRIPTION
<!-- Thanks for sending a PR -->

### Description
<!-- Feature description or reference to fixed issue -->
This PR adds a script for an easy (example) generation of a specific user kubeconfig with restricted permissions at only one namespace on the K8s cluster.

### Checklist
Before submitting this PR, please make sure:
- [x] your code builds clean with `make`
- [x] your code lets succeed unit tests with `make test`
- [x] your code lets succeed integration tests
<!-- Please delete options that are not relevant -->
