### PR TITLE
Update manual installation instructions for custom seccomp profiles

### DIFF
--- a/docs/manualInstallation.md
+++ b/docs/manualInstallation.md
@@ -29,6 +29,12 @@ Configure the annotations for karydia:
 kubectl apply -f manifests/karydia/templates/workaround-annotate-kube-system-namespace.yaml
 ```
 
+Create and distribute custom seccomp profiles (only if applicable):
+```
+kubectl apply -f manifests/karydia/templates/custom-seccomp-profiles.yaml
+kubectl apply -f manifests/karydia/templates/custom-seccomp-daemonset.yaml
+```
+
 Create a configmap that holds the scripts for TLS/secrete creation and creates the default network policy:
 ```
 kubectl apply -f manifests/karydia/templates/configmap.yaml


### PR DESCRIPTION
### Description
This is an addition for PR #213. It adds the instructions for installing custom seccomp profiles by hand (without the use of tiller).


### Checklist
Before submitting this PR, please make sure:
- [x] you have documented new or changed features
