### PR TITLE
Use the "--namespace" CLI flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ See all [features and options](docs/features.md).
 ```
 kubectl apply -f ./install/helm-service-account.yaml
 helm init --service-account tiller
-helm install ./install/charts --name karydia ---namespace karydia --set dev.active=true
+helm install ./install/charts --name karydia --namespace karydia --set dev.active=true
 ```
 
 ##### Build, Swap and Test

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ See all [features and options](docs/features.md).
 ```
 kubectl apply -f ./install/helm-service-account.yaml
 helm init --service-account tiller
-helm install ./install/charts --name karydia --set dev.active=true
+helm install ./install/charts --name karydia ---namespace karydia --set dev.active=true
 ```
 
 ##### Build, Swap and Test

--- a/docs/manualInstallation.md
+++ b/docs/manualInstallation.md
@@ -26,7 +26,7 @@ kubectl apply -f manifests/karydia/templates/karydia-network-policy.yaml
 
 Create the namespace for karydia and configure the annotations:
 ```
-kubectl apply -f manifests/karydia/templates/karydia-namespace.yaml
+kubectl create namespace karydia
 kubectl apply -f manifests/karydia/templates/workaround-annotate-kube-system-namespace.yaml
 ```
 

--- a/docs/manualInstallation.md
+++ b/docs/manualInstallation.md
@@ -9,7 +9,7 @@ The manual process consists of the following steps:
 First, generate the manifests from the helm templates:
 ```
 mkdir manifests
-helm template ./install/charts/ --output-dir manifests
+helm template ./install/charts/ --output-dir manifests --namespace karydia
 ```
 
 The files for the manual installation will be stored in folder `/manifests/karydia/templates/`.

--- a/install/README.md
+++ b/install/README.md
@@ -18,7 +18,7 @@ helm init --service-account tiller
 ## Delpoy karydia
 Next, to deploy karydia simply run:
 ```
-helm install ./install/charts --name karydia
+helm install ./install/charts --name karydia --namespace karydia
 ```
 
 ## Make sure that karydia is runnning
@@ -36,6 +36,6 @@ karydia is up and running, if the following information is logged:
 ## Development
 If you want to install the development image, simply run:
 ```
-helm install ./install/charts --name karydia --set dev.active=true
+helm install ./install/charts --name karydia --namespace karydia --set dev.active=true
 ```
 Otherwise, you can set `dev.active` to `true` in the `values.yaml` file.

--- a/install/charts/templates/configmap.yaml
+++ b/install/charts/templates/configmap.yaml
@@ -20,7 +20,7 @@ metadata:
   name: {{ .Values.metadata.name }}-tmp
   labels:
     app: {{ .Values.metadata.labelApp }}
-  namespace: {{ .Values.metadata.namespace }}
+  namespace: {{ .Release.Namespace }}
 data:
   configure-karydia-webhook.sh: |-
     {{- include "configure-karydia-webhook.sh.tpl" . | indent 4}}

--- a/install/charts/templates/configure-karydia-webhook.sh.tpl
+++ b/install/charts/templates/configure-karydia-webhook.sh.tpl
@@ -38,7 +38,7 @@ webhooks:
     clientConfig:
       service:
         name: {{ .Values.metadata.name }}
-        namespace: {{ .Values.metadata.namespace }}
+        namespace: {{ .Release.Namespace }}
         path: "/webhook/validating"
       caBundle: §CA_BUNDLE§
     rules:
@@ -105,7 +105,7 @@ webhooks:
     clientConfig:
       service:
         name: {{ .Values.metadata.name }}
-        namespace: {{ .Values.metadata.namespace }}
+        namespace: {{ .Release.Namespace }}
         path: "/webhook/mutating"
       caBundle: §CA_BUNDLE§
     rules:

--- a/install/charts/templates/create-karydia-certificate.sh.tpl
+++ b/install/charts/templates/create-karydia-certificate.sh.tpl
@@ -31,7 +31,7 @@ readonly service_name="${SERVICE_NAME:-karydia}"
 readonly secret_name="${SECRET_NAME:-karydia-tls}"
 readonly cert_path="${CERT_PATH:-karydia.pem}"
 readonly key_path="${KEY_PATH:-karydia-key.pem}"
-readonly namespace="${NAMESPACE:-{{ .Values.metadata.namespace }}}"
+readonly namespace="${NAMESPACE:-{{ .Release.Namespace }}}"
 
 readonly csr_name="${service_name}.${namespace}"
 

--- a/install/charts/templates/create-karydia-tls-secret.sh.tpl
+++ b/install/charts/templates/create-karydia-tls-secret.sh.tpl
@@ -22,7 +22,7 @@ set -euo pipefail
 readonly secret_name="${SECRET_NAME:-karydia-tls}"
 readonly cert_path="${CERT_PATH:-karydia.pem}"
 readonly key_path="${KEY_PATH:-karydia-key.pem}"
-readonly namespace="${NAMESPACE:-{{ .Values.metadata.namespace }}}"
+readonly namespace="${NAMESPACE:-{{ .Release.Namespace }}}"
 
 kubectl create secret generic "${secret_name}" \
   --from-file=key.pem="${key_path}" \

--- a/install/charts/templates/custom-seccomp-daemonset.yaml
+++ b/install/charts/templates/custom-seccomp-daemonset.yaml
@@ -20,7 +20,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ .Values.metadata.name }}-seccomp
-  namespace: kube-system
+  namespace: {{ .Values.metadata.namespace }}
   labels:
     security: seccomp
     app: {{ .Values.metadata.labelApp }}

--- a/install/charts/templates/custom-seccomp-daemonset.yaml
+++ b/install/charts/templates/custom-seccomp-daemonset.yaml
@@ -20,11 +20,11 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ .Values.metadata.name }}-seccomp
-  namespace: {{ .Values.metadata.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     security: seccomp
     app: {{ .Values.metadata.labelApp }}
-  namespace: {{ .Values.metadata.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   selector:
     matchLabels:

--- a/install/charts/templates/custom-seccomp-profiles.yaml
+++ b/install/charts/templates/custom-seccomp-profiles.yaml
@@ -20,7 +20,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: custom-seccomp-profiles
-  namespace: {{ .Values.metadata.namespace }}
+  namespace: {{ .Release.Namespace }}
 data:
 {{ $root := . }}
 {{ range $path, $bytes := $customSeccompProfiles }}

--- a/install/charts/templates/delete-clean-up.yaml
+++ b/install/charts/templates/delete-clean-up.yaml
@@ -18,7 +18,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.rbac.serviceAccount }}-cleanup
-  namespace: {{ .Values.metadata.namespace }}
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
@@ -60,7 +60,7 @@ metadata:
     "helm.sh/hook-weight": "3"
 subjects:
 - kind: ServiceAccount
-  namespace: {{ .Values.metadata.namespace }}
+  namespace: {{ .Release.Namespace }}
   name: {{ .Values.rbac.serviceAccount }}-cleanup
 roleRef:
   kind: ClusterRole
@@ -75,7 +75,7 @@ metadata:
   name: {{ .Values.metadata.name }}-cleanup
   labels:
     app: {{ .Values.metadata.labelApp }}
-  namespace: {{ .Values.metadata.namespace }}
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-delete-policy": hook-succeeded, hook-failed

--- a/install/charts/templates/deployment.yaml
+++ b/install/charts/templates/deployment.yaml
@@ -20,7 +20,7 @@ metadata:
   name: {{ .Values.metadata.name }}
   labels:
     app: {{ .Values.metadata.labelApp }}
-  namespace: {{ .Values.metadata.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
   template:

--- a/install/charts/templates/karydia-namespace.yaml
+++ b/install/charts/templates/karydia-namespace.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-delete-policy": before-hook-creation, hook-failed
-    "helm.sh/hook-weight": "0"
-  name: {{ .Values.metadata.namespace }}

--- a/install/charts/templates/post-install-webhook.yaml
+++ b/install/charts/templates/post-install-webhook.yaml
@@ -18,7 +18,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.rbac.serviceAccount }}-post-install
-  namespace: {{ .Values.metadata.namespace }}
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": post-install
     "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
@@ -57,7 +57,7 @@ metadata:
     "helm.sh/hook-weight": "3"
 subjects:
 - kind: ServiceAccount
-  namespace: {{ .Values.metadata.namespace }}
+  namespace: {{ .Release.Namespace }}
   name: {{ .Values.rbac.serviceAccount }}-post-install
 roleRef:
   kind: ClusterRole
@@ -72,7 +72,7 @@ metadata:
   name: {{ .Values.metadata.name }}-post
   labels:
     app: {{ .Values.metadata.labelApp }}
-  namespace: {{ .Values.metadata.namespace }}
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": post-install
     "helm.sh/hook-delete-policy": hook-succeeded, hook-failed

--- a/install/charts/templates/rbac.yaml
+++ b/install/charts/templates/rbac.yaml
@@ -18,7 +18,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.rbac.serviceAccount }}
-  namespace: {{ .Values.metadata.namespace }}
+  namespace: {{ .Release.Namespace }}
 
 ---
 
@@ -50,7 +50,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.rbac.serviceAccount }}
-  namespace: {{ .Values.metadata.namespace }}
+  namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: {{ .Values.metadata.name }}-init
@@ -78,7 +78,7 @@ metadata:
   name: {{ .Values.metadata.name }}-namespaces
 subjects:
 - kind: ServiceAccount
-  namespace: {{ .Values.metadata.namespace }}
+  namespace: {{ .Release.Namespace }}
   name: {{ .Values.rbac.serviceAccount }}
 roleRef:
   kind: ClusterRole
@@ -106,7 +106,7 @@ metadata:
   name: {{ .Values.metadata.name }}-karydiaconfig
 subjects:
 - kind: ServiceAccount
-  namespace: {{ .Values.metadata.namespace }}
+  namespace: {{ .Release.Namespace }}
   name: {{ .Values.rbac.serviceAccount }}
 roleRef:
   kind: ClusterRole
@@ -134,7 +134,7 @@ metadata:
   name: {{ .Values.metadata.name }}-karydianetworkpolicies
 subjects:
 - kind: ServiceAccount
-  namespace: {{ .Values.metadata.namespace }}
+  namespace: {{ .Release.Namespace }}
   name: {{ .Values.rbac.serviceAccount }}
 roleRef:
   kind: ClusterRole
@@ -162,7 +162,7 @@ metadata:
   name: {{ .Values.metadata.name }}-roles
 subjects:
 - kind: ServiceAccount
-  namespace: {{ .Values.metadata.namespace }}
+  namespace: {{ .Release.Namespace }}
   name: {{ .Values.rbac.serviceAccount }}
 roleRef:
   kind: ClusterRole
@@ -190,7 +190,7 @@ metadata:
   name: {{ .Values.metadata.name }}-networkpolicies
 subjects:
 - kind: ServiceAccount
-  namespace: {{ .Values.metadata.namespace }}
+  namespace: {{ .Release.Namespace }}
   name: {{ .Values.rbac.serviceAccount }}
 roleRef:
   kind: ClusterRole

--- a/install/charts/templates/service.yaml
+++ b/install/charts/templates/service.yaml
@@ -18,7 +18,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.metadata.name }}
-  namespace: {{ .Values.metadata.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Values.metadata.labelApp }}
 spec:

--- a/install/charts/templates/workaround-annotate-kube-system-namespace.yaml
+++ b/install/charts/templates/workaround-annotate-kube-system-namespace.yaml
@@ -25,7 +25,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.rbac.serviceAccount }}-workaround
-  namespace: {{ .Values.metadata.namespace }}
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
@@ -58,7 +58,7 @@ metadata:
     "helm.sh/hook-weight": "3"
 subjects:
 - kind: ServiceAccount
-  namespace: {{ .Values.metadata.namespace }}
+  namespace: {{ .Release.Namespace }}
   name: {{ .Values.rbac.serviceAccount }}-workaround
 roleRef:
   kind: ClusterRole
@@ -71,7 +71,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ .Values.metadata.name }}-workaround
-  namespace: {{ .Values.metadata.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Values.metadata.labelApp }}
   annotations:
@@ -92,7 +92,7 @@ spec:
         - --overwrite=true
         - namespace
         - kube-system
-        - {{ .Values.metadata.namespace }}
+        - {{ .Release.Namespace }}
         - karydia.gardener.cloud/workaroundForIssue=183
         - karydia.gardener.cloud/seccompProfile=unconfined
         - karydia.gardener.cloud/podSecurityContext=none

--- a/install/charts/values.yaml
+++ b/install/charts/values.yaml
@@ -41,7 +41,6 @@ dev:
 metadata:
   name: "karydia"
   apiGroup: "karydia.gardener.cloud"
-  namespace: "karydia"
   labelApp: "karydia"
 rbac:
   apiGroup: "rbac.authorization.k8s.io"


### PR DESCRIPTION
### Description
This PR removes the YAML file that creates the "karydia" namespace during the installation process and let Helm handle the namespace via the `--namespace` CLI flag.

Resolves #224.

### Checklist
Before submitting this PR, please make sure:
- [x] your code builds clean with `make`
- [x] your code lets succeed unit tests with `make test`
- [x] your code lets succeed integration tests
- [x] you have documented new or changed features
