### PR TITLE
Move Feature Description to Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,6 @@ Karydia inverts the following insecure default settings:
 
 A description of each feature can be found [here](docs/feature.md) and an overview of the application of these features is described in the [demo section](docs/demos/overview.md).
 
-Karydia is implemented as [webhook admission
-controller](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/)
-and is configurable through a custom Kubernetes resource.
-
 ## Installing Karydia
 To install Karydia using Helm run the following commands:
 ```

--- a/README.md
+++ b/README.md
@@ -21,45 +21,6 @@ and is configurable through a custom Kubernetes resource.
 ## Installing Karydia
 [Install](install/README.md) Karydia with a helm chart.
 
-## Demo
-### Invert the Pod Defaults
-The following screenshot shows the pod specification without the usage of Karydia:
-* Service accout token is mounted
-* A user is not specified (so the pod uses root by default)
-* No seccomp profile is assigned
-```
-kubectl run -it --rm --restart=Never alpine --image=alpine sh -n demo
-kubectl edit  pod/alpine -n demo
-```
-![](docs/images/pod-without-karydia.png)
-
-If you create a pod after the installation of Karydia, the pod description is different, even if you use the same commands:
-* No service account token is mounted
-* A user is specified (the root user is not used)
-* The seccomp profile runtime/default is assigned
-
-```
-kubectl run -it --rm --restart=Never alpine --image=alpine sh -n demo
-kubectl edit  pod/alpine -n demo
-```
-![](docs/images/pod-with-karydia.png)
-
-### Add a Network Policy
-Karydia adds a default network policy to each namespace and reconciles it.
-```
-kubectl get networkpolicy -n demo
-```
-![](docs/images/networkpolicy.png)
-
-## Features and Configuration Options
-You can configure each feature to meet the needs of your applications:
-* A custom seccomp profile
-* A custom default network policy
-* A specific network policy per namespace
-* The usage of a root user if necessary
-
-See all [features and options](docs/features.md).
-
 ## Testing
 
 ### Integration Tests

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Karydia inverts the following insecure default settings:
 * Run with minimal privileges by adding a non-root user
 * Restrict network communication by adding a network policy to each namespace
 
-A description of each feature can be found [here](docs/feature.md) and an overview of the application of these features is describe in the [demo section](docs/demos/overview.md).
+A description of each feature can be found [here](docs/feature.md) and an overview of the application of these features is described in the [demo section](docs/demos/overview.md).
 
 Karydia is implemented as [webhook admission
 controller](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/)

--- a/README.md
+++ b/README.md
@@ -12,12 +12,21 @@ Karydia inverts the following insecure default settings:
 * Run with minimal privileges by adding a non-root user
 * Restrict network communication by adding a network policy to each namespace
 
+A description of each feature can be found [here](docs/feature.md) and an overview of the application of these features is describe in the [demo section](docs/demos/overview.md).
+
 Karydia is implemented as [webhook admission
 controller](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/)
 and is configurable through a custom Kubernetes resource.
 
 ## Installing Karydia
-[Install](install/README.md) Karydia with a helm chart.
+To install Karydia using Helm run the following commands:
+```
+kubectl apply -f ./install/helm-service-account.yaml
+helm init --service-account tiller
+helm install ./install/charts --name karydia
+```
+
+A detailed description of the installation process can be found in the [corresponding readme](install/README.md).
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@ Karydia is implemented as [webhook admission
 controller](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/)
 and is configurable through a custom Kubernetes resource.
 
-![](docs/images/karydia-architecture.png)
-
 ## Installing Karydia
 [Install](install/README.md) Karydia with a helm chart.
 

--- a/docs/demos/overview.md
+++ b/docs/demos/overview.md
@@ -1,0 +1,38 @@
+## Overview of Features provided by karydia
+### Invert the Pod Defaults
+The following screenshot shows the pod specification without the usage of Karydia:
+* Service accout token is mounted
+* A user is not specified (so the pod uses root by default)
+* No seccomp profile is assigned
+```
+kubectl run -it --rm --restart=Never alpine --image=alpine sh -n demo
+kubectl edit  pod/alpine -n demo
+```
+![](./images/pod-without-karydia.png)
+
+If you create a pod after the installation of Karydia, the pod description is different, even if you use the same commands:
+* No service account token is mounted
+* A user is specified (the root user is not used)
+* The seccomp profile runtime/default is assigned
+
+```
+kubectl run -it --rm --restart=Never alpine --image=alpine sh -n demo
+kubectl edit  pod/alpine -n demo
+```
+![](./images/pod-with-karydia.png)
+
+### Add a Network Policy
+Karydia adds a default network policy to each namespace and reconciles it.
+```
+kubectl get networkpolicy -n demo
+```
+![](./images/networkpolicy.png)
+
+## Features and Configuration Options
+You can configure each feature to meet the needs of your applications:
+* A custom seccomp profile
+* A custom default network policy
+* A specific network policy per namespace
+* The usage of a root user if necessary
+
+See all [features and options](./features.md).

--- a/docs/demos/overview.md
+++ b/docs/demos/overview.md
@@ -8,7 +8,7 @@ The following screenshot shows the pod specification without the usage of Karydi
 kubectl run -it --rm --restart=Never alpine --image=alpine sh -n demo
 kubectl edit  pod/alpine -n demo
 ```
-![](./images/pod-without-karydia.png)
+![](../images/pod-without-karydia.png)
 
 If you create a pod after the installation of Karydia, the pod description is different, even if you use the same commands:
 * No service account token is mounted
@@ -19,14 +19,14 @@ If you create a pod after the installation of Karydia, the pod description is di
 kubectl run -it --rm --restart=Never alpine --image=alpine sh -n demo
 kubectl edit  pod/alpine -n demo
 ```
-![](./images/pod-with-karydia.png)
+![](../images/pod-with-karydia.png)
 
 ### Add a Network Policy
 Karydia adds a default network policy to each namespace and reconciles it.
 ```
 kubectl get networkpolicy -n demo
 ```
-![](./images/networkpolicy.png)
+![](../images/networkpolicy.png)
 
 ## Features and Configuration Options
 You can configure each feature to meet the needs of your applications:
@@ -35,4 +35,4 @@ You can configure each feature to meet the needs of your applications:
 * A specific network policy per namespace
 * The usage of a root user if necessary
 
-See all [features and options](./features.md).
+See all [features and options](../features.md).


### PR DESCRIPTION
### Description
<!-- Feature description or reference to fixed issue -->
From my point of view, should the initial readme be short and give new users a basic overview of the project.

Thus, I think we should move the more detailed feature description to the docs folder of the project. Moreover, I don't see the benefit of the "architectural" overview of Karydia, as it does not add any more information to the readme.

I am open to feedback or other opinions on this topic, as it is highly subjective.

### Checklist
Before submitting this PR, please make sure:
- [x] you have documented new or changed features
