### PR TITLE
GitHub Pages Fix Links

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ helm init --service-account tiller
 helm install ./install/charts --name karydia --namespace karydia
 ```
 
-A detailed description of the installation process can be found in the [corresponding readme](../install/README.md).
+A detailed description of the installation process can be found in the [corresponding readme](https://github.com/karydia/karydia/blob/master/install/README.md).
 
 ## Development
 For developers we provide an [architectural overview](./devel/architecture.md) and instructions to use a [hot swap technology](./devel/hotswap.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ Karydia inverts the following insecure default settings:
 * Restrict network communication by adding a network policy to each namespace
 
 A description of each feature can be found [here](./features.md) and an overview of the application of these features is described in the [demo section](./demos/overview.md). This project provides some demos providing instructions for the features provided by Karydia. This includes:
-- A basic tutorial about [seccomp profile](./demos/seccomp.md) and instructions to use [custom seccomp profiles](custom_seccomp.d).
+- A basic tutorial about [seccomp profile](./demos/seccomp.md) and instructions to use [custom seccomp profiles](custom_seccomp.nd).
 
 ## Installing Karydia
 To install Karydia using Helm run the following commands:
@@ -21,4 +21,4 @@ helm install ./install/charts --name karydia --namespace karydia
 A detailed description of the installation process can be found in the [corresponding readme](../install/README.md).
 
 ## Development
-For developers we provide an [architectural overview](./devel/architecture.md) and instructions to use a [hot swap technology](./hotswap.md).
+For developers we provide an [architectural overview](./devel/architecture.md) and instructions to use a [hot swap technology](./devel/hotswap.md).


### PR DESCRIPTION
### Description
Fixed two links that contained typos and added a full link for the "external" installation README, which is not in the `docs` folder and cannot be accessed via GitHub pages.

### Checklist
Before submitting this PR, please make sure:
- [x] you have documented new or changed features
