### PR TITLE
Update Deployment Accordingly Kubernetes Version 1.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG golangImageTag=1.12.9
+ARG golangImageTag=1.13.3
 ARG alpineImageTag=3.10.2
 
 # build

--- a/install/charts/templates/deployment.yaml
+++ b/install/charts/templates/deployment.yaml
@@ -45,9 +45,6 @@ spec:
           {{- if .Values.dev.active }}
           - hotswap-dev
           - -r
-          {{- if gt .Values.dev.timeoutIncreaseValue 0.0 }}
-          - t{{ .Values.dev.timeoutIncreaseValue }}
-          {{- end }}
           - 'dlv --listen=:2345 --headless=true --api-version=2 --accept-multiclient
             exec {{"{{"}}binPath{{"}}"}} --'
           - --

--- a/install/charts/templates/deployment.yaml
+++ b/install/charts/templates/deployment.yaml
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.metadata.name }}
@@ -23,6 +23,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Values.metadata.labelApp }}
   template:
     metadata:
       labels:


### PR DESCRIPTION
### Description
Kubernetes `1.16` changed the version for a deployment from `extensions/v1beta1` to `apps/v1` and requires a `selector` field. As Helm `2.15` was released, we should support the current Kubernetes version. This PR implements the needed changes.

Fixes #223.
Fixes #232.

### Checklist
Before submitting this PR, please make sure:
- [x] your code builds clean with `make`
- [x] your code lets succeed unit tests with `make test`
- [x] your code lets succeed integration tests