### PR TITLE
Re-add Option to Increase Timeout

### DIFF
--- a/install/charts/templates/deployment.yaml
+++ b/install/charts/templates/deployment.yaml
@@ -45,6 +45,9 @@ spec:
           {{- if .Values.dev.active }}
           - hotswap-dev
           - -r
+          {{- if gt .Values.dev.timeoutIncreaseValue 0.0 }}
+          - t{{ .Values.dev.timeoutIncreaseValue }}
+          {{- end }}
           - 'dlv --listen=:2345 --headless=true --api-version=2 --accept-multiclient
             exec {{"{{"}}binPath{{"}}"}} --'
           - --


### PR DESCRIPTION
### Description
In PR #233 I removed the option to increase the timeout value as Helm `2.15` had a problem with numeric values. Helm `2.15.1` was released and fixed this issues (for more information see #234).

Thus, I re-added the option to increase the timeout.

Fixes #234.

### Checklist
Before submitting this PR, please make sure:
- [x] your code builds clean with `make`
- [x] your code lets succeed unit tests with `make test`
- [x] your code lets succeed integration tests