### PR TITLE
Introduce Version Restrictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Karydia Logo](logo/Karydia@0.5x.png)
 
-Status: Beta
+** Status: Beta ** | ** Kubernetes Version >=1.15.x **
 
 Karydia is a security add-on for Kubernetes, which helps you follow good security practices by inverting insecure default settings in Kubernetes. Kubernetes default settings are not optimized for security, but rather on running out-of-the-box without complicated configuration upfront. It's easy to get a pod up and running; in the simplest case it's just one command. Unfortunately, the simple setup does not have a highly secure application in mind. Default settings are not enough!
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Karydia Logo](logo/Karydia@0.5x.png)
 
-** Status: Beta ** | ** Kubernetes Version >=1.15.x **
+**Status: Beta** | **Kubernetes Version >=1.15.x**
 
 Karydia is a security add-on for Kubernetes, which helps you follow good security practices by inverting insecure default settings in Kubernetes. Kubernetes default settings are not optimized for security, but rather on running out-of-the-box without complicated configuration upfront. It's easy to get a pod up and running; in the simplest case it's just one command. Unfortunately, the simple setup does not have a highly secure application in mind. Default settings are not enough!
 

--- a/install/charts/Chart.yaml
+++ b/install/charts/Chart.yaml
@@ -17,7 +17,7 @@
 apiVersion: v1
 name: karydia
 version: 0.2.0
-kubeVersion: >=1.15
+kubeVersion: ">= 1.15"
 description: A Helm chart for karydia
 keywords:
   - karydia

--- a/install/charts/Chart.yaml
+++ b/install/charts/Chart.yaml
@@ -16,7 +16,8 @@
 
 apiVersion: v1
 name: karydia
-version: 0.1.0
+version: 0.2.0
+kubeVersion: >=1.15
 description: A Helm chart for karydia
 keywords:
   - karydia

--- a/install/charts/templates/configure-karydia-webhook.sh.tpl
+++ b/install/charts/templates/configure-karydia-webhook.sh.tpl
@@ -35,6 +35,7 @@ metadata:
 webhooks:
   - name: {{ .Values.metadata.apiGroup }}
     failurePolicy: Ignore
+    timeoutSeconds: 10
     clientConfig:
       service:
         name: {{ .Values.metadata.name }}


### PR DESCRIPTION
<!-- Thanks for sending a PR -->

### Description

>> Reduce the timeout for the validation and mutating webhooks down to `10` seconds. The default timeout of `30` seconds interfered with the API server timeout.

> Due to compatibility issues with older Kubernetes versions, we decided to remove nodes as resources registered for the webhooks instead of reducing the timeout. This solved the hibernation problem and we stay compatible with older k8s versions.

Due to compatibility issues with older Kubernetes versions, we decided to only support versions `>=1.15`. This stated in the README when visiting the Karydia project and is tracked in the `Charts.yaml` for the Helm installation.

Fixes #235


### Checklist
Before submitting this PR, please make sure:
- [x] your code builds clean with `make`
- [x] your code lets succeed unit tests with `make test`
<!-- Please delete options that are not relevant -->
