### PR TITLE
Updated Namespace to Lower Case in Installation Instruction

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -18,7 +18,7 @@ helm init --service-account tiller
 ## Delpoy Karydia
 Next, to deploy Karydia simply run:
 ```
-helm install ./install/charts --name karydia --namespace Karydia
+helm install ./install/charts --name karydia --namespace karydia
 ```
 
 ## Make sure that Karydia is runnning


### PR DESCRIPTION
### Description
In the installation construction the namespace should be `karydia` and not `Karydia` to keep consistent with the overall documentation.

### Checklist
Before submitting this PR, please make sure:
- [x] you have documented new or changed features
