### PR TITLE
Update chart version to "0.2.1"

### DIFF
--- a/install/charts/Chart.yaml
+++ b/install/charts/Chart.yaml
@@ -16,7 +16,7 @@
 
 apiVersion: v1
 name: karydia
-version: 0.2.0
+version: 0.2.1
 kubeVersion: ">= 1.15"
 description: A Helm chart for karydia
 keywords:


### PR DESCRIPTION
### Description
As the last PR #241 changed some parts of the installation (mainly the naming from `networkPolicy` to `networkPolicies`), we should have updated the version in the `Chart.yaml`.

I bumped the version from `0.2.0` to `0.2.1`.

### Checklist
Before submitting this PR, please make sure:
- [x] your code builds clean with `make`
- [x] your code lets succeed unit tests with `make test`
- [x] your code lets succeed integration tests
- [x] you have documented new or changed features
