### PR TITLE
[Network Policy Reconciler] Fix Update Buffer Fail

### DIFF
--- a/pkg/controller/networkpolicy_reconciler.go
+++ b/pkg/controller/networkpolicy_reconciler.go
@@ -271,7 +271,7 @@ func (reconciler *NetworkpolicyReconciler) syncNetworkPolicy(namespaceName strin
 		}
 	}
 
-	if npName == reconciler.defaultNetworkPolicies[npName].GetName() && stringInSlice(npName, expectedNpNames) {
+	if stringInSlice(npName, expectedNpNames) && npName == reconciler.defaultNetworkPolicies[npName].GetName() {
 		networkPolicy, err := reconciler.networkPolicyLister.NetworkPolicies(namespaceName).Get(npName)
 		if err != nil {
 			if errors.IsNotFound(err) {

--- a/pkg/controller/networkpolicy_reconciler.go
+++ b/pkg/controller/networkpolicy_reconciler.go
@@ -260,7 +260,7 @@ func (reconciler *NetworkpolicyReconciler) syncNetworkPolicyHandler(key string) 
 }
 
 func (reconciler *NetworkpolicyReconciler) syncNetworkPolicy(namespaceName string, npName string, setting Setting) error {
-        expectedNpNames := strings.Split(setting.value, defaultNetworkPoiliciesDelimiter)
+	expectedNpNames := strings.Split(setting.value, defaultNetworkPoiliciesDelimiter)
 
 	for _, expectedNpName := range expectedNpNames {
 		if _, ok := reconciler.defaultNetworkPolicies[expectedNpName]; !ok {
@@ -269,6 +269,7 @@ func (reconciler *NetworkpolicyReconciler) syncNetworkPolicy(namespaceName strin
 				return nil
 			}
 		}
+	}
 
 	if npName == reconciler.defaultNetworkPolicies[npName].GetName() && stringInSlice(npName, expectedNpNames) {
 		networkPolicy, err := reconciler.networkPolicyLister.NetworkPolicies(namespaceName).Get(npName)

--- a/pkg/controller/networkpolicy_reconciler.go
+++ b/pkg/controller/networkpolicy_reconciler.go
@@ -180,7 +180,6 @@ func (reconciler *NetworkpolicyReconciler) processNextNetworkPolicyWorkItem() bo
 		}
 
 		reconciler.networkPolicyworkqueue.Forget(obj)
-		reconciler.log.Infof("Successfully synced network policy '%s'", key)
 		return nil
 	}(obj)
 
@@ -217,7 +216,6 @@ func (reconciler *NetworkpolicyReconciler) processNextNamespaceWorkItem() bool {
 		}
 
 		reconciler.namespaceWorkqueue.Forget(obj)
-		reconciler.log.Infof("Successfully synced workitem '%s'", key)
 		return nil
 	}(obj)
 

--- a/pkg/controller/networkpolicy_reconciler.go
+++ b/pkg/controller/networkpolicy_reconciler.go
@@ -260,14 +260,15 @@ func (reconciler *NetworkpolicyReconciler) syncNetworkPolicyHandler(key string) 
 }
 
 func (reconciler *NetworkpolicyReconciler) syncNetworkPolicy(namespaceName string, npName string, setting Setting) error {
-	if _, ok := reconciler.defaultNetworkPolicies[npName]; !ok {
-		if err := reconciler.updateBuffer(npName); err != nil {
-			reconciler.log.Warnf("Failed to get default network policy '%s'", npName)
-			return nil
-		}
-	}
+        expectedNpNames := strings.Split(setting.value, defaultNetworkPoiliciesDelimiter)
 
-	expectedNpNames := strings.Split(setting.value, defaultNetworkPoiliciesDelimiter)
+	for _, expectedNpName := range expectedNpNames {
+		if _, ok := reconciler.defaultNetworkPolicies[expectedNpName]; !ok {
+			if err := reconciler.updateBuffer(expectedNpName); err != nil {
+				reconciler.log.Warnf("Failed to get default network policy '%s'", expectedNpName)
+				return nil
+			}
+		}
 
 	if npName == reconciler.defaultNetworkPolicies[npName].GetName() && stringInSlice(npName, expectedNpNames) {
 		networkPolicy, err := reconciler.networkPolicyLister.NetworkPolicies(namespaceName).Get(npName)


### PR DESCRIPTION
### Description
When i.e. deleting a network policy that is not managed by Karydia, the logs will print out an error message as Karydia tries to find the examined network policy within the buffer. However, the buffer only contains network policies managed by Karydia.

Thus, I changed the `updateBuffer` section to update the buffer according the karydia-default-network-policies instead of the examined network policy.

Resolves #244.

### Checklist
Before submitting this PR, please make sure:
- [x] your code builds clean with `make`
- [x] your code lets succeed unit tests with `make test`
- [x] your code lets succeed integration tests
