### PR TITLE
Add "overwrite" Flag to Label Command in Init-Container

### DIFF
--- a/install/charts/templates/deployment.yaml
+++ b/install/charts/templates/deployment.yaml
@@ -89,7 +89,7 @@ spec:
       initContainers:
       - name: pre-install-{{ .Values.metadata.name }}
         image: lachlanevenson/k8s-kubectl
-        command: ['sh', '-c', 'apk add --update --no-cache openssl && kubectl label namespace kube-system karydia.gardener.cloud/name=kube-system && sh /tmp/create-karydia-certificate.sh && sh /tmp/create-karydia-tls-secret.sh']
+        command: ['sh', '-c', 'apk add --update --no-cache openssl && kubectl label --overwrite namespace kube-system karydia.gardener.cloud/name=kube-system && sh /tmp/create-karydia-certificate.sh && sh /tmp/create-karydia-tls-secret.sh']
         volumeMounts:
         - name: workdir
           mountPath: "/tmp"


### PR DESCRIPTION
### Description
When scaling the Karydia deployment (i.e. while hibernating) and re-scaling the deployment, the init container may fail starting. This is due to the following command:
```
kubectl label namespace kube-system karydia.gardener.cloud/name=kube-system
```

As the label already exists, the command fails and the pod cannot start. To fix this issue, one needs to add the `overwrite` flag to the command.


### Checklist
Before submitting this PR, please make sure:
- [x] your code builds clean with `make`
- [x] your code lets succeed unit tests with `make test`
- [x] your code lets succeed integration tests
