### PR TITLE
[BUGFIX] Allow Deletion of Not Mutated Pods

### DIFF
--- a/pkg/admission/karydia/admission.go
+++ b/pkg/admission/karydia/admission.go
@@ -94,6 +94,11 @@ func (k *KarydiaAdmission) Admit(ar v1beta1.AdmissionReview, mutationAllowed boo
 			return k8sutil.ErrToAdmissionResponse(err)
 		}
 
+		k.logger.Infoln("POD STATUS (CALC): ", getPodStatus(pod)) 
+		if (getPodStatus(pod) == "Terminating") {
+			return k8sutil.AllowAdmissionResponse()
+		}
+
 		if mutationAllowed {
 			return k.mutatePod(pod, namespace)
 		}
@@ -154,4 +159,68 @@ func shouldIgnoreEvent(ar v1beta1.AdmissionReview) bool {
 		return true
 	}
 	return false
+}
+
+// https://github.com/kubernetes/kubernetes/blob/a38096a0696514a034de7f8d0cc5a3ec5e7da8ff/pkg/printers/internalversion/printers.go#L659-L781
+func getPodStatus(pod *v1.Pod) string {
+	reason := string(pod.Status.Phase)
+
+	initializing := false
+	for i := range pod.Status.InitContainerStatuses {
+		container := pod.Status.InitContainerStatuses[i]
+		switch {
+		case container.State.Terminated != nil && container.State.Terminated.ExitCode == 0:
+			continue
+		case container.State.Terminated != nil:
+			// initialization is failed
+			if len(container.State.Terminated.Reason) == 0 {
+				if container.State.Terminated.Signal != 0 {
+					reason = fmt.Sprintf("Init:Signal:%d", container.State.Terminated.Signal)
+				} else {
+					reason = fmt.Sprintf("Init:ExitCode:%d", container.State.Terminated.ExitCode)
+				}
+			} else {
+				reason = "Init:" + container.State.Terminated.Reason
+			}
+			initializing = true
+		case container.State.Waiting != nil && len(container.State.Waiting.Reason) > 0 && container.State.Waiting.Reason != "PodInitializing":
+			reason = "Init:" + container.State.Waiting.Reason
+			initializing = true
+		default:
+			reason = fmt.Sprintf("Init:%d/%d", i, len(pod.Spec.InitContainers))
+			initializing = true
+		}
+		break
+	}
+	if !initializing {
+		hasRunning := false
+		for i := len(pod.Status.ContainerStatuses) - 1; i >= 0; i-- {
+			container := pod.Status.ContainerStatuses[i]
+
+			if container.State.Waiting != nil && container.State.Waiting.Reason != "" {
+				reason = container.State.Waiting.Reason
+			} else if container.State.Terminated != nil && container.State.Terminated.Reason != "" {
+				reason = container.State.Terminated.Reason
+			} else if container.State.Terminated != nil && container.State.Terminated.Reason == "" {
+				if container.State.Terminated.Signal != 0 {
+					reason = fmt.Sprintf("Signal:%d", container.State.Terminated.Signal)
+				} else {
+					reason = fmt.Sprintf("ExitCode:%d", container.State.Terminated.ExitCode)
+				}
+			} else if container.Ready && container.State.Running != nil {
+				hasRunning = true
+			}
+		}
+
+		// change pod status back to "Running" if there is at least one container still reporting as "Running" status
+		if reason == "Completed" && hasRunning {
+			reason = "Running"
+		}
+	}
+
+	if pod.DeletionTimestamp != nil {
+		reason = "Terminating"
+	}
+
+	return reason
 }

--- a/tests/e2e/admission_test.go
+++ b/tests/e2e/admission_test.go
@@ -1,0 +1,132 @@
+// Copyright (C) 2019 SAP SE or an SAP affiliate company. All rights reserved.
+// This file is licensed under the Apache Software License, v. 2 except as
+// noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestTerminatingPod(t *testing.T) {
+	err := setAdmission(false)
+	if err != nil {
+		t.Fatal("Could not change admission in karydiaConfig", err)
+	}
+
+	// Create pod
+	namespace, err := f.CreateTestNamespace()
+	if err != nil {
+		t.Fatal("failed to create test namespace:", err)
+	}
+
+	ns := namespace.ObjectMeta.Name
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "karydia-e2e-test-pod",
+			Namespace: ns,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "nginx",
+					Image: "nginx",
+				},
+			},
+		},
+	}
+
+	createdPod, err := f.KubeClientset.CoreV1().Pods(ns).Create(pod)
+	if err != nil {
+		t.Fatal("failed to create pod:", err)
+	}
+
+	timeout := 2 * time.Minute
+	if err = f.WaitPodRunning(ns, pod.ObjectMeta.Name, timeout); err != nil {
+		t.Fatal("pod never reached state running")
+	}
+
+	// Check pod
+	if profile := createdPod.ObjectMeta.Annotations["seccomp.security.alpha.kubernetes.io/pod"]; profile != "unconfined" {
+		t.Fatalf("expected seccomp profile to be %v but is %v", "unconfined", profile)
+	}
+
+	if createdPod.Spec.SecurityContext != nil {
+		t.Fatal("expected security context not to be defined by admission")
+	}
+
+	err = setAdmission(true)
+	if err != nil {
+		t.Fatal("Could not change admission in karydiaConfig", err)
+	}
+
+	// Delete pod
+	err = f.KubeClientset.CoreV1().Pods(ns).Delete(pod.ObjectMeta.Name, &metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatal("could not delete pod")
+	}
+
+	timeout = 1 * time.Minute
+	if err = f.WaitPodDeleted(ns, pod.ObjectMeta.Name, timeout); err != nil {
+		t.Fatal("pod was never deleted")
+	}
+}
+
+// helper functions
+
+func setAdmission(admission bool) error {
+	curKarydiaConfig, curErr := f.KarydiaClientset.KarydiaV1alpha1().KarydiaConfigs().Get("karydia-config", metav1.GetOptions{})
+
+	if curErr != nil {
+		return curErr
+	}
+
+	// This does not disable the admission but does not change the pod
+	if admission {
+		curKarydiaConfig.Spec.SeccompProfile = "unconfined"
+		curKarydiaConfig.Spec.PodSecurityContext = "none"
+		curKarydiaConfig.Spec.AutomountServiceAccountToken = "no-change"
+	} else {
+		curKarydiaConfig.Spec.SeccompProfile = "runtime/default"
+		curKarydiaConfig.Spec.PodSecurityContext = "nobody"
+		curKarydiaConfig.Spec.AutomountServiceAccountToken = "change-default"
+	}
+
+	f.KarydiaClientset.KarydiaV1alpha1().KarydiaConfigs().Update(curKarydiaConfig)
+
+	newKarydiaConfig, newErr := f.KarydiaClientset.KarydiaV1alpha1().KarydiaConfigs().Get("karydia-config", metav1.GetOptions{})
+
+	if newErr != nil {
+		return newErr
+	}
+
+	if admission {
+		if newKarydiaConfig.Spec.SeccompProfile != "unconfined" && newKarydiaConfig.Spec.PodSecurityContext != "none" && newKarydiaConfig.Spec.AutomountServiceAccountToken != "no-change" {
+			return fmt.Errorf("admission in karydiaConfig did not change but should")
+		}
+	} else {
+		if newKarydiaConfig.Spec.SeccompProfile != "change-default" && newKarydiaConfig.Spec.PodSecurityContext != "nobody" && newKarydiaConfig.Spec.AutomountServiceAccountToken != "runtime/default" {
+			return fmt.Errorf("admission in karydiaConfig did not change but should")
+		}
+	}
+
+	return nil
+}

--- a/tests/e2e/framework/framework.go
+++ b/tests/e2e/framework/framework.go
@@ -202,6 +202,16 @@ func (f *Framework) WaitPodRunning(namespace, name string, timeout time.Duration
 	})
 }
 
+func (f *Framework) WaitPodDeleted(namespace, name string, timeout time.Duration) error {
+	return wait.Poll(3*time.Second, timeout, func() (bool, error) {
+		_, err := f.KubeClientset.CoreV1().Pods(namespace).Get(name, metav1.GetOptions{})
+		if err == nil {
+			return true, nil
+		}
+		return false, nil
+	})
+}
+
 func (f *Framework) WaitDefaultServiceAccountCreated(ns string, timeout time.Duration) error {
 	return wait.Poll(200*time.Millisecond, timeout, func() (bool, error) {
 		_, err := f.KubeClientset.CoreV1().ServiceAccounts(ns).Get("default", metav1.GetOptions{})


### PR DESCRIPTION
### Description
If a pod is running in your cluster that has not been mutated yet (e.g. the security context is not set) and you want to delete it, it get stuck in the state `Terminating`. This due to Karydia trying to change the pod definition and denying the `UPDATE` event (which is created with the `DELETE` event).

Thus, this PR introduces a check that ignores pods that are in the state `Terminating` in the admission controller. I introduced a function from the Kubernetes internals to "calculate" the correct state of the pod, as the phase of the pod is still ´Terminating`, even though it is actually starting to terminate.

This function reliable detects a terminating pod. However, this internal state change (depending on the containers in the pod) may take a few seconds and one can experience a delay in the deletion process. However, the deletion will always 

[Fixes #250]

### Checklist
Before submitting this PR, please make sure:
- [x] you have added unit tests
- [x] you have added integration tests
- [x] your code builds clean with `make`
- [x] your code lets succeed unit tests with `make test`
- [x] your code lets succeed integration tests
<!-- Please delete options that are not relevant -->
