### PR TITLE
Remove unused ressources from webhooks

### DIFF
--- a/install/charts/templates/configure-karydia-webhook.sh.tpl
+++ b/install/charts/templates/configure-karydia-webhook.sh.tpl
@@ -55,7 +55,6 @@ webhooks:
         - pods
         - pods/status
         - serviceaccounts
-        - endpoints
         - persistentvolumes
         - validatingwebhookconfigurations
         - mutatingwebhookconfigurations
@@ -103,6 +102,7 @@ metadata:
 webhooks:
   - name: {{ .Values.metadata.apiGroup }}
     failurePolicy: Ignore
+    timeoutSeconds: 10
     clientConfig:
       service:
         name: {{ .Values.metadata.name }}
@@ -122,7 +122,6 @@ webhooks:
         - pods
         - pods/status
         - serviceaccounts
-        - endpoints
         - persistentvolumes
         - validatingwebhookconfigurations
         - mutatingwebhookconfigurations

--- a/install/charts/templates/configure-karydia-webhook.sh.tpl
+++ b/install/charts/templates/configure-karydia-webhook.sh.tpl
@@ -50,14 +50,9 @@ webhooks:
         apiGroups: ["*"]
         apiVersions: ["*"]
         resources:
-        - nodes
-        - namespaces
         - pods
         - pods/status
         - serviceaccounts
-        - persistentvolumes
-        - validatingwebhookconfigurations
-        - mutatingwebhookconfigurations
     {{- if .Values.exclusionNamespaceLabels }}
     namespaceSelector:
       matchExpressions:
@@ -117,14 +112,9 @@ webhooks:
         apiGroups: ["*"]
         apiVersions: ["*"]
         resources:
-        - nodes
-        - namespaces
         - pods
         - pods/status
         - serviceaccounts
-        - persistentvolumes
-        - validatingwebhookconfigurations
-        - mutatingwebhookconfigurations
     {{- if .Values.exclusionNamespaceLabels }}
     namespaceSelector:
       matchExpressions:


### PR DESCRIPTION
### Description
This PR removes `endpoints`, `nodes`, `namespaces`, `persistentvolumes`, `validatingwebhookconfigurations` and `mutatingwebhookconfigurations` from the webhooks, as they are causing troubles hibernating a cluster.

[Fixes #245]

### Checklist
Before submitting this PR, please make sure:
- [x] your code builds clean with `make`
- [x] your code lets succeed unit tests with `make test`
- [x] your code lets succeed integration tests