### PR TITLE
Allow Init-Container to Approve Certificate Requests

### DIFF
--- a/install/charts/templates/rbac.yaml
+++ b/install/charts/templates/rbac.yaml
@@ -37,6 +37,12 @@ rules:
 - apiGroups: ["certificates.k8s.io"]
   resources: ["certificatesigningrequests/approval"]
   verbs: ["update"]
+- apiGroups: ["certificates.k8s.io"]
+  resources:
+    - "signers"
+  resourceNames:
+    - "kubernetes.io/legacy-unknown"
+  verbs: ["approve"]
 - apiGroups: [""]
   resources: ["secrets"]
   verbs: ["create", "get", "patch"]


### PR DESCRIPTION
### Description
Kubernetes 1.18 introduces changes regarding certificates (see https://github.com/kubernetes/kubernetes/pull/86933). This breaks the deployment of Karydia on Kubernetes cluster with version >=1.18.

For certificate request approval, the used role needs to be assigned a "signer" for the respective "singer-name" (see https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/#signers).

This PR adds the needed rbac-rule to the init-container role.

### Checklist
Before submitting this PR, please make sure:
- [x] your code builds clean with `make`
- [x] your code lets succeed unit tests with `make test`
- [x] your code lets succeed integration tests
