### PR TITLE
Increase e2e Test Timeout to 30 Minutes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ container-dev:
 .PHONY: deploy-dev
 deploy-dev:
 	for i in $(shell kubectl get pods -n=karydia --selector=app=karydia --output=jsonpath='{.items[*].metadata.name}'); do \
+		echo "(" $$i ")" \
 		kubectl cp bin/karydia -n karydia $$i:/usr/local/bin/karydia$(DEV_POSTFIX); \
 	done
 

--- a/Makefile
+++ b/Makefile
@@ -82,4 +82,4 @@ test-coverage:
 
 .PHONY: e2e-test
 e2e-test:
-	go test -v ./tests/e2e/... --server $(KUBERNETES_SERVER) --kubeconfig $(KUBECONFIG_PATH)
+	go test -v ./tests/e2e/... -timeout 30m --server $(KUBERNETES_SERVER) --kubeconfig $(KUBECONFIG_PATH)


### PR DESCRIPTION
### Description
This PR increases the timeout of the e2e test to 30 minutes from the default 10 minutes.

See the respective [docs](https://golang.org/cmd/go/#hdr-Testing_flags) for more information.

### Checklist
Before submitting this PR, please make sure:
- [x] your code builds clean with `make`
- [x] your code lets succeed unit tests with `make test`
- [x] your code lets succeed integration tests
