### PR TITLE
Upate Webhooks after Upgrade

### DIFF
--- a/install/charts/Chart.yaml
+++ b/install/charts/Chart.yaml
@@ -17,7 +17,7 @@
 apiVersion: v2
 name: karydia
 type: application
-version: 0.3.2
+version: 0.3.3
 kubeVersion: ">= 1.15"
 description: A Helm chart for Karydia
 keywords:

--- a/install/charts/templates/post-install-webhook.yaml
+++ b/install/charts/templates/post-install-webhook.yaml
@@ -20,7 +20,7 @@ metadata:
   name: {{ .Values.rbac.serviceAccount }}-post-install
   namespace: {{ .Release.Namespace }}
   annotations:
-    "helm.sh/hook": post-install
+    "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
     "helm.sh/hook-weight": "1"
 
@@ -31,7 +31,7 @@ apiVersion: {{ .Values.rbac.apiGroup }}{{ .Values.rbac.apiVersion }}
 metadata:
   name: {{ .Values.metadata.name }}-post
   annotations:
-    "helm.sh/hook": post-install
+    "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
     "helm.sh/hook-weight": "2"
 rules:
@@ -52,7 +52,7 @@ apiVersion: {{ .Values.rbac.apiGroup }}{{ .Values.rbac.apiVersion }}
 metadata:
   name: {{ .Values.metadata.name }}-post
   annotations:
-    "helm.sh/hook": post-install
+    "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
     "helm.sh/hook-weight": "3"
 subjects:

--- a/install/charts/templates/post-install-webhook.yaml
+++ b/install/charts/templates/post-install-webhook.yaml
@@ -74,7 +74,7 @@ metadata:
     app: {{ .Values.metadata.labelApp }}
   namespace: {{ .Release.Namespace }}
   annotations:
-    "helm.sh/hook": post-install
+    "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
     "helm.sh/hook-weight": "4"
 spec:


### PR DESCRIPTION
## Description
This PR reapplies the webhook installation script after an upgrade (not just an install). This allows it to make changes to the webhook without deleting and installing Karydia, but rather just upgrading it.

### Checklist
Before submitting this PR, please make sure:
- [x] your code builds clean with `make`
- [x] your code lets succeed unit tests with `make test`
- [x] your code lets succeed integration tests
