### PR TITLE
Add option in "values.yaml" for Affinity, Tolerations, and Priorityclassname

### DIFF
--- a/install/charts/Chart.yaml
+++ b/install/charts/Chart.yaml
@@ -17,7 +17,7 @@
 apiVersion: v2
 name: karydia
 type: application
-version: 0.3.4
+version: 0.3.5
 kubeVersion: ">= 1.15"
 description: A Helm chart for Karydia
 keywords:

--- a/install/charts/templates/deployment.yaml
+++ b/install/charts/templates/deployment.yaml
@@ -53,11 +53,7 @@ spec:
       {{- end }}
       {{- if .Values.setup.tolerations }}
       tolerations:
-      {{- range .Values.setup.tolerations }}
-      - key: {{ .key | quote }}
-        operator: {{ .operator | quote }}
-        effect: {{ .effect | quote }}
-      {{- end }}
+{{ toYaml .Values.setup.tolerations | indent 8 }}
       {{- end }}
       containers:
       - name: {{ .Values.metadata.name }}

--- a/install/charts/templates/deployment.yaml
+++ b/install/charts/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
         {{- else }}
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: {{ .Values.setup.podAntiAffinityWeight }}
+          - weight: {{ .Values.setup.podAntiAffinityWeight | default 100 }}
             podAffinityTerm:
               labelSelector:
                 matchExpressions:

--- a/install/charts/templates/deployment.yaml
+++ b/install/charts/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
       {{- end }}
       {{- if .Values.setup.tolerations }}
       tolerations:
-{{ toYaml .Values.setup.tolerations | indent 8 }}
+{{ toYaml .Values.setup.tolerations | indent 6 }}
       {{- end }}
       containers:
       - name: {{ .Values.metadata.name }}

--- a/install/charts/templates/deployment.yaml
+++ b/install/charts/templates/deployment.yaml
@@ -33,9 +33,12 @@ spec:
     spec:
       serviceAccount: {{ .Values.rbac.serviceAccount }}
       affinity:
+        {{- if .Values.setup.affinity }}
+{{ toYaml .Values.setup.affinity | indent 8 }} 
+        {{- else }}
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
+          - weight: {{ .Values.setup.podAntiAffinityWeight }}
             podAffinityTerm:
               labelSelector:
                 matchExpressions:
@@ -44,6 +47,18 @@ spec:
                   values:
                   - {{ .Values.metadata.labelApp }}
               topologyKey: "node"
+        {{- end }}
+      {{- if .Values.setup.priorityClassName }}
+      priorityClassName: {{ .Values.setup.priorityClassName }}
+      {{- end }}
+      {{- if .Values.setup.tolerations }}
+      tolerations:
+      {{- range .Values.setup.tolerations }}
+      - key: {{ .key | quote }}
+        operator: {{ .operator | quote }}
+        effect: {{ .effect | quote }}
+      {{- end }}
+      {{- end }}
       containers:
       - name: {{ .Values.metadata.name }}
         {{- if .Values.dev.active }}

--- a/install/charts/values.yaml
+++ b/install/charts/values.yaml
@@ -59,7 +59,6 @@ metadata:
 setup:
   replicas: 3
   minReplicas: 1
-  podAntiAffinityWeight: 100
 rbac:
   apiGroup: "rbac.authorization.k8s.io"
   apiVersion: "/v1"

--- a/install/charts/values.yaml
+++ b/install/charts/values.yaml
@@ -59,6 +59,7 @@ metadata:
 setup:
   replicas: 3
   minReplicas: 1
+  podAntiAffinityWeight: 100
 rbac:
   apiGroup: "rbac.authorization.k8s.io"
   apiVersion: "/v1"


### PR DESCRIPTION
### Description
This PR allows the following values to be defined under key `setup` in the `values.yaml`:
0. `podAntiAffinityWeight` - single value. For example:
```
podAntiAffinityWeight: 100
```

1. `affinity` - fully customizable. For example:
```
  affinity:
    podAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
      - labelSelector:
          matchExpressions:
          - key: security
            operator: In
            values:
            - S1
        topologyKey: failure-domain.beta.kubernetes.io/zone
```

2. `priorityClassName` - single value. For example:
```
  priorityClassName: high-priority
```

3. `tolerations` - fully customizable. For example:
```
  tolerations:
  - key: "example-key"
    operator: "Exists"
    effect: "NoSchedule
```

These changes does not change the default behavior, but gives the user more flexibility in adapting the Karydia deployment.

### Checklist
Before submitting this PR, please make sure:
- [x] your code builds clean with `make`
- [x] your code lets succeed unit tests with `make test`
- [x] your code lets succeed integration tests
