### PR TITLE
Make Pod SecurityContext Mutation more accurate

### DIFF
--- a/tests/e2e/admission_security_context_test.go
+++ b/tests/e2e/admission_security_context_test.go
@@ -150,6 +150,85 @@ func TestSecurityContextWithNamespaceAnnotationDefinedContext(t *testing.T) {
 	}
 }
 
+func TestSecurityContextWithNamespaceAnnotationDefinedContext2(t *testing.T) {
+	annotation := map[string]string{
+		"karydia.gardener.cloud/podSecurityContext": "nobody",
+	}
+	namespace, err := f.CreateTestNamespaceWithAnnotation(annotation)
+	if err != nil {
+		t.Fatal("failed to create test namespace:", err)
+	}
+
+	ns := namespace.ObjectMeta.Name
+
+	var uid int64 = 1000
+	var fsgid int64 = 2000
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "karydia-e2e-test-pod",
+			Namespace: ns,
+		},
+		Spec: corev1.PodSpec{
+			SecurityContext: &corev1.PodSecurityContext{
+				FSGroup: &fsgid,
+			},
+			Containers: []corev1.Container{
+				{
+					Name:  "redis",
+					Image: "redis",
+					SecurityContext: &corev1.SecurityContext{
+						RunAsUser: &uid,
+					},
+				},
+			},
+		},
+	}
+
+	createdPod, err := f.KubeClientset.CoreV1().Pods(ns).Create(pod)
+	if err != nil {
+		t.Fatal("failed to create pod:", err)
+	}
+
+	secCtx := createdPod.Spec.SecurityContext
+	if secCtx == nil {
+		t.Fatal("expected security context to be defined but is nil")
+	} else if secCtx.RunAsUser == nil {
+		t.Fatal("expected security context user id to be defined but is nil")
+	} else if *secCtx.RunAsUser != 65534 {
+		t.Fatalf("expected security context user id to be %v but is %v", 65534, *secCtx.RunAsUser)
+	} else if secCtx.RunAsGroup == nil {
+		t.Fatal("expected security context group id to be defined but is nil")
+	} else if *secCtx.RunAsGroup != 65534 {
+		t.Fatalf("expected security context group id to be %v but is %v", 65534, *secCtx.RunAsGroup)
+	} else if secCtx.FSGroup == nil {
+		t.Fatal("expected security context fs group id to be defined but is nil")
+	} else if *secCtx.FSGroup != fsgid {
+		t.Fatalf("expected security context fs group id to be %v but is %v", fsgid, *secCtx.FSGroup)
+	}
+
+	containers := createdPod.Spec.Containers
+	for i := range containers {
+		secCtxContainers := createdPod.Spec.Containers[i].SecurityContext
+		if secCtxContainers == nil {
+			t.Fatal("expected security context to be definded by but is nil")
+		} else if secCtxContainers.AllowPrivilegeEscalation == nil {
+			t.Fatal("expected container security context allow privilege escalation to be defined but is nil")
+		} else if *secCtxContainers.AllowPrivilegeEscalation != false {
+			t.Fatalf("expected container security context allow privilege escalation to be %v but is %v", false, *secCtxContainers.AllowPrivilegeEscalation)
+		} else if secCtxContainers.RunAsUser == nil {
+			t.Fatal("expected container security context user id to be defined but is nil")
+		} else if *secCtxContainers.RunAsUser != uid {
+			t.Fatalf("expected container security context user id to be %v but is %v", uid, *secCtxContainers.RunAsUser)
+		}
+	}
+
+	timeout := 2 * time.Minute
+	if err := f.WaitPodRunning(pod.ObjectMeta.Namespace, pod.ObjectMeta.Name, timeout); err != nil {
+		t.Fatal("pod never reached state running")
+	}
+}
+
 func TestSecurityContextWithoutNamespaceAnnotationUndefinedContextFromConfig(t *testing.T) {
 	annotation := map[string]string{}
 	namespace, err := f.CreateTestNamespaceWithAnnotation(annotation)


### PR DESCRIPTION
Currently (if pre-conditions are fulfilled),  Karydia will override an existing pod security context, and just set runAsUser and runAsGroup. Other previously existing attributes (such as fsGroup) will get lost. Which probably should not be the case, as Karydia claims to only own runAsUser and runAsGroup.

This PR tries to fix this behaviour, so that in an existing pod security context, only runAsUser and runAsGroup will be patched by Karydia.

A similar behaviour was observed in the logic where Karydia patches existing container security contexts. This is also covered by this PR.