### PR TITLE
Change failurePolicy to "Fail" and add reinvocationPolicy "IfNeeded"

### DIFF
--- a/install/charts/templates/configure-karydia-webhook.sh.tpl
+++ b/install/charts/templates/configure-karydia-webhook.sh.tpl
@@ -34,7 +34,8 @@ metadata:
     app: {{ .Values.metadata.labelApp }}
 webhooks:
   - name: {{ .Values.metadata.apiGroup }}
-    failurePolicy: Ignore
+    failurePolicy: Fail
+    reinvocationPolicy: IfNeeded
     timeoutSeconds: 10
     clientConfig:
       service:
@@ -96,7 +97,8 @@ metadata:
     app: {{ .Values.metadata.labelApp }}
 webhooks:
   - name: {{ .Values.metadata.apiGroup }}
-    failurePolicy: Ignore
+    failurePolicy: Fail
+    reinvocationPolicy: IfNeeded
     timeoutSeconds: 10
     clientConfig:
       service:


### PR DESCRIPTION
### Description
This PR changes two things:
1. It changes the failurePolicy from `Ignore` to `Fail`. I argue that it might be problematic if the Karydia webhook fails silently. It should rather fail and throw an error. Also see https://github.com/karydia/karydia/issues/2

https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#failure-policy
2. It sets the reinvocationPolicy to `IfNeeded`. Thus, the webhook may be called if the object being admitted is modified by other webhooks after the initial webhook call. For example, if the Karydia webhook is invoked for an object and modifies it, another webhook could modify it later on, then the Karydia webhook should be called again to enforce the security policies.
(For me it seems like this scenario is limited in the number of calls if changes appears on an already mutated object. See https://github.com/kubernetes/enhancements/pull/1049).
https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#reinvocation-policy


### Checklist
Before submitting this PR, please make sure:
- [x] your code builds clean with `make`
- [x] your code lets succeed unit tests with `make test`
- [x] your code lets succeed integration tests
